### PR TITLE
Moved conflicting structures to kernel/api/common

### DIFF
--- a/kernel/apis/EnvironmentAPI.proto
+++ b/kernel/apis/EnvironmentAPI.proto
@@ -1,9 +1,6 @@
 syntax = "proto3";
 
-message ContentMapping {
-    string file = 1;
-    string hash = 2;
-}
+import "common/ContentMapping.proto";
 
 message MinimalRunnableEntity {
     repeated ContentMapping content = 1;

--- a/kernel/apis/ParcelIdentity.proto
+++ b/kernel/apis/ParcelIdentity.proto
@@ -1,9 +1,6 @@
 syntax = "proto3";
 
-message ContentMapping {
-    string file = 1;
-    string hash = 2;
-}
+import "common/ContentMapping.proto";
 
 message MappingsResponse  {
     string parcel_id = 1;

--- a/kernel/apis/Players.proto
+++ b/kernel/apis/Players.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-import "UserIdentity.proto";
+import "common/UserData.proto";
 
 message Player {
     string user_id = 1;

--- a/kernel/apis/UserIdentity.proto
+++ b/kernel/apis/UserIdentity.proto
@@ -1,27 +1,6 @@
 syntax = "proto3";
 
-message Snapshots {
-    string face256 = 1;
-    string body = 2;
-}
-
-message AvatarForUserData {
-    string body_shape = 1;
-    string skin_color = 2;
-    string hair_color = 3;
-    string eye_color = 4;
-    repeated string wearables = 5;
-    Snapshots snapshots = 6;
-}
-
-message UserData {
-    string display_name = 1;
-    optional string public_key = 2;
-    bool has_connected_web3 = 3;
-    string user_id = 4;
-    int32 version = 5;
-    AvatarForUserData avatar = 6;
-}
+import "common/UserData.proto";
 
 message GetUserDataRequest {}
 

--- a/kernel/apis/common/ContentMapping.proto
+++ b/kernel/apis/common/ContentMapping.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message ContentMapping {
+    string file = 1;
+    string hash = 2;
+}

--- a/kernel/apis/common/UserData.proto
+++ b/kernel/apis/common/UserData.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+message Snapshots {
+    string face256 = 1;
+    string body = 2;
+}
+
+message AvatarForUserData {
+    string body_shape = 1;
+    string skin_color = 2;
+    string hair_color = 3;
+    string eye_color = 4;
+    repeated string wearables = 5;
+    Snapshots snapshots = 6;
+}
+
+message UserData {
+    string display_name = 1;
+    optional string public_key = 2;
+    bool has_connected_web3 = 3;
+    string user_id = 4;
+    int32 version = 5;
+    AvatarForUserData avatar = 6;
+}


### PR DESCRIPTION
When trying to build the protocol with `protoc` I got a bunch of errors regarding re-defined messages in the kernel api proto files.

I moved the conflicting redefinitions to a common folder following the pattern you had for the ecs components shared structures.

I needed this to compile the protocol with Rust.