### PR TITLE
add rightof prop to UITransform

### DIFF
--- a/ecs/components/UiTransform.proto
+++ b/ecs/components/UiTransform.proto
@@ -79,8 +79,9 @@ enum YGEdge {
 }
 
 message PBUiTransform {
-  int64 parent = 79;
-  
+  int32 parent = 79;
+  int32 rightOf = 80;
+
   YGPositionType position_type = 1;
 
   YGAlign align_content = 2;

--- a/ecs/components/UiTransform.proto
+++ b/ecs/components/UiTransform.proto
@@ -80,7 +80,7 @@ enum YGEdge {
 
 message PBUiTransform {
   int32 parent = 79;
-  int32 rightOf = 80;
+  int32 right_of = 80;
 
   YGPositionType position_type = 1;
 


### PR DESCRIPTION
## What ? 
- Update parent `int64` to `int32`
- Add RightOf prop

## Why ? https://github.com/decentraland/sdk/issues/397
We need this props to generate the tree.


