### PR TITLE
fix: add albedo color to BasicMaterial

### DIFF
--- a/proto/decentraland/sdk/components/material.proto
+++ b/proto/decentraland/sdk/components/material.proto
@@ -21,6 +21,7 @@ message PBMaterial {
     optional decentraland.common.TextureUnion texture = 1; // default = null
     optional float alpha_test = 2; // default = 0.5. range value: from 0 to 1
     optional bool cast_shadows = 3; // default =  true
+    optional decentraland.common.Color4 albedo_color = 4; // default = white;
   }
 
   message PbrMaterial {


### PR DESCRIPTION
This PR fixes [SDK issue #485](https://github.com/decentraland/sdk/issues/485) and adds the albedo_color property to BasicMaterial