### PR TITLE
Use consistent naming for materials

### DIFF
--- a/proto/decentraland/sdk/components/material.proto
+++ b/proto/decentraland/sdk/components/material.proto
@@ -21,7 +21,7 @@ message PBMaterial {
     optional decentraland.common.TextureUnion texture = 1; // default = null
     optional float alpha_test = 2; // default = 0.5. range value: from 0 to 1
     optional bool cast_shadows = 3; // default =  true
-    optional decentraland.common.Color4 albedo_color = 4; // default = white;
+    optional decentraland.common.Color4 diffuse_color = 4; // default = white;
   }
 
   message PbrMaterial {


### PR DESCRIPTION
Albedo only applies to PBR pipelines, what we are looking for is "diffuse"

Signed-off-by: menduz <github@menduz.com>