### PR TITLE
remove all visible meshes

### DIFF
--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -45,7 +45,7 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_VISIBLE_MESHES = 4; // all visible meshes, use with extreme care since the performance penalty is high
+  CL_RESERVED1 = 4;
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;


### PR DESCRIPTION
It was a misunderstanding. All colliders need to be explicitly created by scene creators to foster good performance practices