### PR TITLE
feat: add auth token to each procedure 

### DIFF
--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -75,7 +75,7 @@ message CancelPayload { User user = 1; }
 
 message UpdateFriendshipPayload {
   FriendshipEventPayload event = 1;
-  AuthToken auth_token = 2;
+  optional RequestPayload auth_token = 2;
 }
 
 message UpdateFriendshipResponse {
@@ -89,14 +89,14 @@ message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;
 }
 
-message AuthToken { string synapse_token = 1; }
+message RequestPayload { optional string synapse_token = 1; }
 
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(AuthToken) returns (stream Users) {}
+  rpc GetFriends(RequestPayload) returns (stream Users) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(AuthToken) returns (RequestEvents) {}
+  rpc GetRequestEvents(RequestPayload) returns (RequestEvents) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
   rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
@@ -104,6 +104,6 @@ service FriendshipsService {
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
-  rpc SubscribeFriendshipEventsUpdates(AuthToken)
+  rpc SubscribeFriendshipEventsUpdates(RequestPayload)
       returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
 }

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -6,6 +6,11 @@
 syntax = "proto3";
 package decentraland.social.friendships;
 
+enum ServiceErrorCode {
+  INTERNAL_SERVER_ERROR = 0;
+  UNAUTHORIZED = 1;
+}
+
 // Validation and anti-spam errors
 enum FriendshipErrorCode {
   TOO_MANY_REQUESTS_SENT = 0;
@@ -18,7 +23,7 @@ enum FriendshipErrorCode {
 
 // This message is a response that is sent from the server to the client
 message FriendshipEventResponse {
-  oneof body {
+  oneof response {
     RequestResponse request = 1;
     AcceptResponse accept = 2;
     RejectResponse reject = 4;
@@ -99,19 +104,29 @@ message Payload {
   optional string synapse_token = 1;
 }
 
+message ServiceResponse {
+  oneof response {
+    ServiceErrorCode error = 1;
+    Users friends = 2;
+    RequestEvents request_events = 3;
+    UpdateFriendshipResponse update_friendship = 4;
+    SubscribeFriendshipEventsUpdatesResponse events_updates = 5;
+  }
+}
+
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(Payload) returns (stream Users) {}
+  rpc GetFriends(Payload) returns (stream ServiceResponse) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(Payload) returns (RequestEvents) {}
+  rpc GetRequestEvents(Payload) returns (ServiceResponse) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
-  rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
-      returns (UpdateFriendshipResponse) {}
+  rpc UpdateFriendshipEvent(UpdateFriendshipPayload) returns (ServiceResponse) {
+  }
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
   rpc SubscribeFriendshipEventsUpdates(Payload)
-      returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
+      returns (stream ServiceResponse) {}
 }

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -80,6 +80,7 @@ message CancelPayload { User user = 1; }
 
 message UpdateFriendshipPayload {
   FriendshipEventPayload event = 1;
+  // For internal use only, subject to change.
   optional Payload auth_token = 2;
 }
 

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -80,7 +80,7 @@ message CancelPayload { User user = 1; }
 
 message UpdateFriendshipPayload {
   FriendshipEventPayload event = 1;
-  optional RequestPayload auth_token = 2;
+  optional Payload auth_token = 2;
 }
 
 message UpdateFriendshipResponse {
@@ -94,17 +94,17 @@ message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;
 }
 
-message RequestPayload {
+message Payload {
   // For internal use only, subject to change.
   optional string synapse_token = 1;
 }
 
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(RequestPayload) returns (stream Users) {}
+  rpc GetFriends(Payload) returns (stream Users) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(RequestPayload) returns (RequestEvents) {}
+  rpc GetRequestEvents(Payload) returns (RequestEvents) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
   rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
@@ -112,6 +112,6 @@ service FriendshipsService {
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
-  rpc SubscribeFriendshipEventsUpdates(RequestPayload)
+  rpc SubscribeFriendshipEventsUpdates(Payload)
       returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
 }

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -1,3 +1,7 @@
+// ***
+// For internal use only, in beta version of the protocol.
+// ***
+
 syntax = "proto3";
 package decentraland.social.friendships;
 

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -75,7 +75,10 @@ message CancelResponse { User user = 1; }
 
 message CancelPayload { User user = 1; }
 
-message UpdateFriendshipPayload { FriendshipEventPayload event = 1; }
+message UpdateFriendshipPayload {
+  FriendshipEventPayload event = 1;
+  AuthToken auth_token = 2;
+}
 
 message UpdateFriendshipResponse {
   oneof response {
@@ -88,12 +91,14 @@ message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;
 }
 
+message AuthToken { string synapse_token = 1; }
+
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(google.protobuf.Empty) returns (stream Users) {}
+  rpc GetFriends(AuthToken) returns (stream User) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(google.protobuf.Empty) returns (RequestEvents) {}
+  rpc GetRequestEvents(AuthToken) returns (RequestEvents) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
   rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
@@ -101,6 +106,6 @@ service FriendshipsService {
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
-  rpc SubscribeFriendshipEventsUpdates(google.protobuf.Empty)
+  rpc SubscribeFriendshipEventsUpdates(AuthToken)
       returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
 }

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package decentraland.social.friendships;
 
-import "google/protobuf/empty.proto";
-
 // Validation and anti-spam errors
 enum FriendshipErrorCode {
   TOO_MANY_REQUESTS_SENT = 0;

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -1,6 +1,6 @@
 // ***
-// For internal use only, in beta version of the protocol.
-// Subject to change.
+// FOR INTERNAL USE ONLY, IN BETA VERSION OF THE PROTOCOL.
+// SUBJECT TO CHANGE.
 // ***
 
 syntax = "proto3";
@@ -94,7 +94,10 @@ message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;
 }
 
-message RequestPayload { optional string synapse_token = 1; }
+message RequestPayload {
+  // For internal use only, subject to change.
+  optional string synapse_token = 1;
+}
 
 service FriendshipsService {
   // Get the list of friends for the authenticated user

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -6,11 +6,6 @@
 syntax = "proto3";
 package decentraland.social.friendships;
 
-enum ServiceErrorCode {
-  INTERNAL_SERVER_ERROR = 0;
-  UNAUTHORIZED = 1;
-}
-
 // Validation and anti-spam errors
 enum FriendshipErrorCode {
   TOO_MANY_REQUESTS_SENT = 0;
@@ -23,7 +18,7 @@ enum FriendshipErrorCode {
 
 // This message is a response that is sent from the server to the client
 message FriendshipEventResponse {
-  oneof response {
+  oneof body {
     RequestResponse request = 1;
     AcceptResponse accept = 2;
     RejectResponse reject = 4;
@@ -104,29 +99,19 @@ message Payload {
   optional string synapse_token = 1;
 }
 
-message ServiceResponse {
-  oneof response {
-    ServiceErrorCode error = 1;
-    Users friends = 2;
-    RequestEvents request_events = 3;
-    UpdateFriendshipResponse update_friendship = 4;
-    SubscribeFriendshipEventsUpdatesResponse events_updates = 5;
-  }
-}
-
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(Payload) returns (stream ServiceResponse) {}
+  rpc GetFriends(Payload) returns (stream Users) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(Payload) returns (ServiceResponse) {}
+  rpc GetRequestEvents(Payload) returns (RequestEvents) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
-  rpc UpdateFriendshipEvent(UpdateFriendshipPayload) returns (ServiceResponse) {
-  }
+  rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
+      returns (UpdateFriendshipResponse) {}
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
   rpc SubscribeFriendshipEventsUpdates(Payload)
-      returns (stream ServiceResponse) {}
+      returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
 }

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -1,5 +1,6 @@
 // ***
 // For internal use only, in beta version of the protocol.
+// Subject to change.
 // ***
 
 syntax = "proto3";

--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -93,7 +93,7 @@ message AuthToken { string synapse_token = 1; }
 
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(AuthToken) returns (stream User) {}
+  rpc GetFriends(AuthToken) returns (stream Users) {}
 
   // Get the list of request events for the authenticated user
   rpc GetRequestEvents(AuthToken) returns (RequestEvents) {}


### PR DESCRIPTION
Each procedure will be updated to include the `Payload` parameter, allowing for individual authentication handling on each message. 

The idea is to revise this solution after Social Service M2 is released and then decide if better Authentication management can be done. So, the definition used is for internal use only, and the release will be marked as beta. The token in each message is strictly "optional", that would make it "always removable".