### PR TITLE
feat: add lamb2 /status endpoint data

### DIFF
--- a/proto/decentraland/bff/http_endpoints.proto
+++ b/proto/decentraland/bff/http_endpoints.proto
@@ -51,6 +51,12 @@ message AboutResponse {
     optional string commit_hash = 3;
     string public_url = 4;
   }
+  message Lamb2Info {
+    // common properties
+    bool healthy = 1;
+    optional string version = 2;
+    optional string commit_hash = 3;
+  }
   message CommsInfo {
     // common properties
     bool healthy = 1;


### PR DESCRIPTION
Expose information for lamb2 /status endpoint that now it will be consumed by the BFF /about endpoint. My understanding is that currently we don't have any public url for lamb2 since all the redirects are managed by NGINx deciding whether to server lambdas o lamb2, that's why this property was skipped.