### PR TITLE
expand runtime

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,12 @@
   "containerEnv": {
     "DCL_DISABLE_ANALYTICS": "true",
     "SHELL": "/usr/bin/zsh"
-  }
+},
+"customizations": {
+	"vscode": {
+		"extensions": [
+			"zxh404.vscode-proto3"
+		]
+	}
+}
 }

--- a/proto/decentraland/kernel/apis/environment_api.proto
+++ b/proto/decentraland/kernel/apis/environment_api.proto
@@ -59,7 +59,7 @@ message GetExplorerConfigurationRequest {}
 message GetDecentralandTimeRequest {}
 
 service EnvironmentApiService {
-  // @deprecated, only available for SDK6 compatibility
+  // @deprecated, only available for SDK6 compatibility. Use runtime_api instead
   rpc GetBootstrapData(GetBootstrapDataRequest) returns (BootstrapDataResponse) {}
   // @deprecated, only available for SDK6 compatibility. Needs migration
   rpc IsPreviewMode(IsPreviewModeRequest) returns (PreviewModeResponse) {}

--- a/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -1,11 +1,7 @@
 syntax = "proto3";
 package decentraland.kernel.apis;
 
-message Vector3 {
-    float x = 1;
-    float y = 2;
-    float z = 3;
-}
+import "decentraland/common/vectors.proto";
 
 message MovePlayerToResponse { }
 

--- a/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -6,13 +6,13 @@ import "decentraland/common/vectors.proto";
 message MovePlayerToResponse { }
 
 message MovePlayerToRequest {
-  Vector3 new_relative_position = 1;
-  optional Vector3 camera_target = 2;
+  decentraland.common.Vector3 new_relative_position = 1;
+  optional decentraland.common.Vector3 camera_target = 2;
 }
 
 message TeleportToRequest {
-  Vector3 world_position = 1;
-  optional Vector3 camera_target = 2;
+  decentraland.common.Vector3 world_position = 1;
+  optional decentraland.common.Vector3 camera_target = 2;
 }
 
 message TriggerEmoteResponse { }

--- a/proto/decentraland/kernel/apis/runtime.proto
+++ b/proto/decentraland/kernel/apis/runtime.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package decentraland.kernel.apis;
 
+import "decentraland/common/content_mapping.proto";
+
 // This API will contain all the information related to the world runtime.
 // Things related to the user, players or the scene itself has they own api, and
 // won't live here. (UserIdentity, Players, ParcelIdentity)
@@ -24,10 +26,40 @@ message GetWorldTimeResponse {
 message GetRealmRequest {}
 message GetWorldTimeRequest {}
 
+message ReadFileRequest {
+  // name of the deployed file
+  string file_name = 1;
+}
+message ReadFileResponse {
+  // contents of the file
+  bytes content = 1;
+  // deployed hash/CID
+  string hash = 2;
+}
+
+message CurrentSceneEntityRequest {}
+message CurrentSceneEntityResponse {
+  // this is either the entityId or the full URN of the scene that is running
+  string urn = 1;
+  // contents of the deployed entities
+  repeated decentraland.common.ContentMapping content = 2;
+  // JSON serialization of the entity.metadata field
+  string metadata_json = 3;
+  // baseUrl used to resolve all content files
+  string base_url = 4;
+}
+
 service RuntimeService {
   // Provides information about the current realm
   rpc GetRealm(GetRealmRequest) returns (GetRealmResponse) {}
   // Provides information about the Decentraland Time, which is coordinated
   // across players.
   rpc GetWorldTime(GetWorldTimeRequest) returns (GetWorldTimeResponse) {}
+  // Returns the file content of a deployed asset. If the file doesn't
+  // exist or cannot be retrieved, the RPC call throws an error.
+  // This method is called to load any assets deployed among the scene,
+  // runtime may cache this response much more than the provided "fetch" function.
+  rpc ReadFile(ReadFileRequest) returns (ReadFileResponse) {}
+  // Returns information about the current scene. This is the replacement of GetBootstrapData
+  rpc GetSceneInformation(CurrentSceneEntityRequest) returns (CurrentSceneEntityResponse) {}
 }


### PR DESCRIPTION
At the moment of writing this issue, we are implementing worker threads for the protocol squad. Currently the only way to get information of the scene is through the `GetBoostrapData` method. And to resolve the actual script of the scene, a regular `fetch` is required. Due to the constraints of the sandboxes of Decentraland, fetch is removed from the runtime unless explicitly requested via scene permisison. That is the motivation behind `Runtime.ReadFile`