### PR TITLE
refactor: remove error option response

### DIFF
--- a/proto/decentraland/social/friendships/friendships.proto
+++ b/proto/decentraland/social/friendships/friendships.proto
@@ -84,12 +84,7 @@ message UpdateFriendshipPayload {
   optional Payload auth_token = 2;
 }
 
-message UpdateFriendshipResponse {
-  oneof response {
-    FriendshipErrorCode error = 1;
-    FriendshipEventResponse event = 2;
-  }
-}
+message UpdateFriendshipResponse { FriendshipEventResponse event = 1; }
 
 message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;


### PR DESCRIPTION
Remove error optional responses and instead allow procedures to return a Result<T, E> with a custom error type that implements RemoteError. This change will allow us to handle error responses and also handle some errors that may occur in the Rust RPC-Server. (See [link](https://github.com/decentraland/rpc-rust/pull/75) for more details.)