### PR TITLE
Glossiness is deprecated in the PBR spec

### DIFF
--- a/proto/decentraland/sdk/components/material.proto
+++ b/proto/decentraland/sdk/components/material.proto
@@ -42,7 +42,7 @@ message PBMaterial {
   
     optional float metallic = 11; // default = 0.5
     optional float roughness = 12; // default = 0.5
-    optional float glossiness = 13; // default = 1
+    reserved 13;
   
     optional float specular_intensity = 14; // default = 1
     optional float emissive_intensity = 15; // default = 2


### PR DESCRIPTION
Use specular instead.

Living spec: https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular
Archived spec: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md