### PR TITLE
feat: (sdk) add player and avatar components

### DIFF
--- a/proto/decentraland/sdk/components/avatar_base.proto
+++ b/proto/decentraland/sdk/components/avatar_base.proto
@@ -5,7 +5,7 @@ import "decentraland/common/colors.proto";
 import "decentraland/sdk/components/common/id.proto";
 option (common.ecs_component_id) = 1087;
 
-// AvatarCustomizations sets all modifiers over the avatar's apparence.
+// AvatarBase sets all modifiers over the avatar's apparence.
 message PBAvatarBase {
   decentraland.common.Color3 skin_color = 1;
   decentraland.common.Color3 eyes_color = 2;

--- a/proto/decentraland/sdk/components/avatar_base.proto
+++ b/proto/decentraland/sdk/components/avatar_base.proto
@@ -6,9 +6,10 @@ import "decentraland/sdk/components/common/id.proto";
 option (common.ecs_component_id) = 1087;
 
 // AvatarCustomizations sets all modifiers over the avatar's apparence.
-message PBAvatarCustomization {
+message PBAvatarBase {
   decentraland.common.Color3 skin_color = 1;
   decentraland.common.Color3 eyes_color = 2;
   decentraland.common.Color3 hair_color = 3;
   string body_shape_urn = 4;
+  string name = 5;
 }

--- a/proto/decentraland/sdk/components/avatar_customization.proto
+++ b/proto/decentraland/sdk/components/avatar_customization.proto
@@ -1,0 +1,14 @@
+
+syntax = "proto3";
+package decentraland.sdk.components;
+import "decentraland/common/colors.proto";
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1087;
+
+// AvatarCustomizations sets all modifiers over the avatar's apparence.
+message PBAvatarCustomization {
+  decentraland.common.Color3 skin_color = 1;
+  decentraland.common.Color3 eyes_color = 2;
+  decentraland.common.Color3 hair_color = 3;
+  string body_shape_urn = 4;
+}

--- a/proto/decentraland/sdk/components/avatar_emote_command.proto
+++ b/proto/decentraland/sdk/components/avatar_emote_command.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1088;
+
+// AvatarEmoteCommand is a grow only value set, used to signal the renderer about
+// avatar emotes playback.
+message PBAvatarEmoteCommand {
+  string emote_urn = 1;
+  uint32 timestamp = 2;
+  bool loop = 3;
+}

--- a/proto/decentraland/sdk/components/avatar_emote_command.proto
+++ b/proto/decentraland/sdk/components/avatar_emote_command.proto
@@ -7,7 +7,10 @@ option (common.ecs_component_id) = 1088;
 // AvatarEmoteCommand is a grow only value set, used to signal the renderer about
 // avatar emotes playback.
 message PBAvatarEmoteCommand {
-  string emote_urn = 1;
-  uint32 timestamp = 2;
-  bool loop = 3;
+  message EmoteCommand {
+    string emote_urn = 1;
+    bool loop = 2;
+  }
+
+  EmoteCommand emote_command = 1;
 }

--- a/proto/decentraland/sdk/components/avatar_equipped_data.proto
+++ b/proto/decentraland/sdk/components/avatar_equipped_data.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1091;
+
+// AvatarEquipData is used to read the information about the avatar's owneables.
+// this component is written by the engine using the communications transports'
+// data.
+message PBAvatarEquippedData {
+  repeated string wearable_urns = 1;
+  repeated string emotes_urns = 2;
+}

--- a/proto/decentraland/sdk/components/player_identity_data.proto
+++ b/proto/decentraland/sdk/components/player_identity_data.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1089;
+
+// PlayerIdentityData is used to read the information about the avatar's identity.
+// this component is written by the engine using the communications transports'
+// data.
+message PBPlayerIdentityData {
+  string address = 1; // ethereum address of this player
+  string name = 2;
+  bool is_guest = 3;
+}

--- a/proto/decentraland/sdk/components/player_identity_data.proto
+++ b/proto/decentraland/sdk/components/player_identity_data.proto
@@ -4,11 +4,10 @@ package decentraland.sdk.components;
 import "decentraland/sdk/components/common/id.proto";
 option (common.ecs_component_id) = 1089;
 
-// PlayerIdentityData is used to read the information about the avatar's identity.
-// this component is written by the engine using the communications transports'
-// data.
+// PlayerIdentityData is used to read the information about the avatar's
+// identity. this component is written by the engine using the communications
+// transports' data.
 message PBPlayerIdentityData {
   string address = 1; // ethereum address of this player
-  string name = 2;
   bool is_guest = 3;
 }

--- a/public/sdk-components.proto
+++ b/public/sdk-components.proto
@@ -5,7 +5,7 @@ import public "decentraland/sdk/components/animator.proto";
 import public "decentraland/sdk/components/audio_source.proto";
 import public "decentraland/sdk/components/audio_stream.proto";
 import public "decentraland/sdk/components/avatar_attach.proto";
-import public "decentraland/sdk/components/avatar_customization.proto";
+import public "decentraland/sdk/components/avatar_base.proto";
 import public "decentraland/sdk/components/avatar_emote_command.proto";
 import public "decentraland/sdk/components/avatar_equipped_data.proto";
 import public "decentraland/sdk/components/avatar_modifier_area.proto";

--- a/public/sdk-components.proto
+++ b/public/sdk-components.proto
@@ -1,11 +1,13 @@
 syntax = "proto3";
 
 package decentraland.sdk.components;
-
 import public "decentraland/sdk/components/animator.proto";
 import public "decentraland/sdk/components/audio_source.proto";
 import public "decentraland/sdk/components/audio_stream.proto";
 import public "decentraland/sdk/components/avatar_attach.proto";
+import public "decentraland/sdk/components/avatar_customization.proto";
+import public "decentraland/sdk/components/avatar_emote_command.proto";
+import public "decentraland/sdk/components/avatar_equipped_data.proto";
 import public "decentraland/sdk/components/avatar_modifier_area.proto";
 import public "decentraland/sdk/components/avatar_shape.proto";
 import public "decentraland/sdk/components/billboard.proto";
@@ -18,6 +20,7 @@ import public "decentraland/sdk/components/material.proto";
 import public "decentraland/sdk/components/mesh_collider.proto";
 import public "decentraland/sdk/components/mesh_renderer.proto";
 import public "decentraland/sdk/components/nft_shape.proto";
+import public "decentraland/sdk/components/player_identity_data.proto";
 import public "decentraland/sdk/components/pointer_events_result.proto";
 import public "decentraland/sdk/components/pointer_events.proto";
 import public "decentraland/sdk/components/pointer_lock.proto";


### PR DESCRIPTION
The original PR split: https://github.com/decentraland/protocol/pull/144
ADR https://github.com/decentraland/adr/pull/251 => https://089fff3d.adr-cvq.pages.dev/adr/ADR-245

These components are read-only for scenes. If you want to spawn a new own Avatar, you do it using the `AvatarShape` component.

The data of these components come from comms.