### PR TITLE
fix: add quests defintions to public

### DIFF
--- a/public/quests.proto
+++ b/public/quests.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package decentraland.quests;
+
+import public "decentraland/quests/definitions.proto";


### PR DESCRIPTION
This PR: 
- makes quest definitions public and compiled :)