### PR TITLE
feat: add `GetExplorerInformation` method in `~system/Runtime` api

### DIFF
--- a/proto/decentraland/kernel/apis/runtime.proto
+++ b/proto/decentraland/kernel/apis/runtime.proto
@@ -49,6 +49,16 @@ message CurrentSceneEntityResponse {
   string base_url = 4;
 }
 
+message GetExplorerInformationRequest {}
+message GetExplorerInformationResponse {
+  // the agent that current explorer is identified as
+  string agent = 1;
+  // options: "desktop", "mobile", "vr", "web"
+  string platform = 2;
+  // custom configurations set in the explorer
+  map<string, string> configurations = 3;
+}
+
 service RuntimeService {
   // Provides information about the current realm
   rpc GetRealm(GetRealmRequest) returns (GetRealmResponse) {}
@@ -62,4 +72,7 @@ service RuntimeService {
   rpc ReadFile(ReadFileRequest) returns (ReadFileResponse) {}
   // Returns information about the current scene. This is the replacement of GetBootstrapData
   rpc GetSceneInformation(CurrentSceneEntityRequest) returns (CurrentSceneEntityResponse) {}
+  
+  // Provides information about the explorer 
+  rpc GetExplorerInformation(GetExplorerInformationRequest) returns (GetExplorerInformationResponse) {}
 }


### PR DESCRIPTION
We had something similar in the `EnvironmentAPI` in SDK6.
It provides info about the current explorer 