### PR TITLE
feat: testing api tool

### DIFF
--- a/proto/decentraland/kernel/apis/runtime.proto
+++ b/proto/decentraland/kernel/apis/runtime.proto
@@ -49,6 +49,16 @@ message CurrentSceneEntityResponse {
   string base_url = 4;
 }
 
+message GetExplorerInformationRequest {}
+message GetExplorerInformationResponse {
+  // the agent that current explorer is identified as
+  string agent = 1;
+  // options: "desktop", "mobile", "vr", "web"
+  string platform = 2;
+  // custom configurations set in the explorer
+  map<string, string> configurations = 3;
+}
+
 service RuntimeService {
   // Provides information about the current realm
   rpc GetRealm(GetRealmRequest) returns (GetRealmResponse) {}
@@ -62,4 +72,7 @@ service RuntimeService {
   rpc ReadFile(ReadFileRequest) returns (ReadFileResponse) {}
   // Returns information about the current scene. This is the replacement of GetBootstrapData
   rpc GetSceneInformation(CurrentSceneEntityRequest) returns (CurrentSceneEntityResponse) {}
+  
+  // Provides information about the explorer 
+  rpc GetExplorerInformation(GetExplorerInformationRequest) returns (GetExplorerInformationResponse) {}
 }

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -31,6 +31,16 @@ message TakeAndCompareScreenshotRequest {
   }
 
   message ComparisonMethodGreyPixelDiff {}
+  
+  enum SnapshotMode {
+    // only visible 3d scene and ui scene
+    3D_AND_UI = 0;
+    // only visible 3d scene
+    3D_ONLY = 1;
+    // only visible ui scene
+    UI_ONLY = 2;
+  };
+  SnapshotMode snapshot_mode = 6;
 }
 
 

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -69,8 +69,21 @@ message TestPlan {
 message TestPlanResponse {}
 
 message SetCameraTransformTestCommand {
-  decentraland.common.Vector3 position = 1;
-  decentraland.common.Quaternion rotation = 2;
+  Vector3 position = 1;
+  Quaternion rotation = 2;
+
+  message Vector3 {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+  }
+
+  message Quaternion {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+    float w = 4;
+  }
 }
 message SetCameraTransformTestCommandResponse {}
 

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package decentraland.kernel.apis;
 
+import "decentraland/common/vectors.proto";
+
 service TestingService {
   // sends a test result to the test runner
   rpc LogTestResult(TestResult) returns (TestResultResponse) {}
@@ -8,8 +10,40 @@ service TestingService {
   rpc Plan(TestPlan) returns (TestPlanResponse) {}
   // sets the camera position and rotation in the engine
   rpc SetCameraTransform (SetCameraTransformTestCommand) returns (SetCameraTransformTestCommandResponse) {}
+  // take a screenshot and compare it with a stored one
+  //  it hides the explorer hud and ui, primary player and players of avatar scenes
+  rpc TakeAndCompareScreenshot (TakeAndCompareScreenshotRequest) returns (TakeAndCompareScreenshotResponse) {}
 }
 
+message TakeAndCompareScreenshotRequest {
+  // the source path in the scene where the screenshot is stored, 
+  //  the snapshot taken is compared with the stored one
+  string src_stored_snapshot = 1;
+  // the camera position where is set before and while taking the screenshot, relative to base scene
+  decentraland.common.Vector3 camera_position = 2;
+  // the camera position where is target to before and while taking the screenshot, relative to base scene
+  decentraland.common.Vector3 camera_target = 3;
+  // width x height screenshot size
+  decentraland.common.Vector2 screenshot_size = 4;
+  // comparison method choice and parameters values
+  oneof comparison_method {
+    ComparisonMethodGreyPixelDiff grey_pixel_diff = 5;
+  }
+
+  message ComparisonMethodGreyPixelDiff {}
+}
+
+
+message TakeAndCompareScreenshotRequest {
+  bool stored_snapshot_found = 1;
+  oneof comparison_method_result {
+    ComparisonMethodGreyPixelDiffResult grey_pixel_diff = 2;
+  }
+
+  message ComparisonMethodGreyPixelDiffResult {
+    float similarity = 1;
+  }
+}
 
 message TestResult {
     string name = 1;
@@ -35,21 +69,8 @@ message TestPlan {
 message TestPlanResponse {}
 
 message SetCameraTransformTestCommand {
-  Vector3 position = 1;
-  Quaternion rotation = 2;
-
-  message Vector3 {
-    float x = 1;
-    float y = 2;
-    float z = 3;
-  }
-
-  message Quaternion {
-    float x = 1;
-    float y = 2;
-    float z = 3;
-    float w = 4;
-  }
+  decentraland.common.Vector3 position = 1;
+  decentraland.common.Quaternion rotation = 2;
 }
 message SetCameraTransformTestCommandResponse {}
 

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -10,11 +10,13 @@ service TestingService {
   rpc Plan(TestPlan) returns (TestPlanResponse) {}
   // sets the camera position and rotation in the engine
   rpc SetCameraTransform (SetCameraTransformTestCommand) returns (SetCameraTransformTestCommandResponse) {}
+  // @internal
   // take a screenshot and compare it with a stored one
   //  it hides the explorer hud and ui, primary player and players of avatar scenes
   rpc TakeAndCompareScreenshot (TakeAndCompareScreenshotRequest) returns (TakeAndCompareScreenshotResponse) {}
 }
 
+// @internal
 message TakeAndCompareScreenshotRequest {
   // the source path in the scene where the screenshot is stored, 
   //  the snapshot taken is compared with the stored one
@@ -44,6 +46,7 @@ message TakeAndCompareScreenshotRequest {
 }
 
 
+// @internal
 message TakeAndCompareScreenshotResponse {
   bool stored_snapshot_found = 1;
   oneof comparison_method_result {

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -34,11 +34,11 @@ message TakeAndCompareScreenshotRequest {
   
   enum SnapshotMode {
     // only visible 3d scene and ui scene
-    3D_AND_UI = 0;
+    SM_3D_AND_UI = 0;
     // only visible 3d scene
-    3D_ONLY = 1;
+    SM_3D_ONLY = 1;
     // only visible ui scene
-    UI_ONLY = 2;
+    SM_UI_ONLY = 2;
   };
   SnapshotMode snapshot_mode = 6;
 }

--- a/proto/decentraland/kernel/apis/testing.proto
+++ b/proto/decentraland/kernel/apis/testing.proto
@@ -34,7 +34,7 @@ message TakeAndCompareScreenshotRequest {
 }
 
 
-message TakeAndCompareScreenshotRequest {
+message TakeAndCompareScreenshotResponse {
   bool stored_snapshot_found = 1;
   oneof comparison_method_result {
     ComparisonMethodGreyPixelDiffResult grey_pixel_diff = 2;


### PR DESCRIPTION
This API enables taking screenshots and comparing with a version stored by the explorer.
- You can make scene tests
- You can make explorer test by making `test-scenes`: https://github.com/decentraland/scene-explorer-tests/

This API is being used here:
https://github.com/decentraland/scene-explorer-tests/

For example, the GLTFContainer test:
- Code with the test: https://github.com/decentraland/scene-explorer-tests/blob/main/52%2C-62-gltf-container/src/tests/gltf-container/index.test.ts#L42
- Snapshot in Bevy: https://github.com/decentraland/bevy-explorer/blob/main/assets/images/screenshots/screenshot%252Fbevy_snapshot_gltfcontainer_avocado.png.png
- Snapshot in Godot: https://github.com/decentraland/godot-explorer/blob/main/tests/snapshots/screenshot_godot_snapshot_gltfcontainer_avocado.png

Disclaimer: the methods are marked as @internal for now, just in case iteration is needed 

More info about the score method:
$$score = \sqrt[]{1 - \frac{1}{3\cdot 255³ \cdot N} \cdot\sum_{N-1}^{i=0}d_i}$$
Where:
$$d_i = (P_{R_i} - Q_{R_i})² + (P_{G_i} - Q_{G_i})² + (P_{B_i} - Q_{B_i})²$$
With:
`P` the taken screenshot and `Q` the stored one, `i` the pixel index and `R`,`G`,`B` the channels

Implementation example: https://github.com/decentraland/godot-explorer/blob/9f8389d5e9db1d7699c46769df14ed2a88c88eb3/rust/decentraland-godot-lib/src/test_runner/testing_tools.rs#L20

This means: `score=1` the screenshot is the same as the stored one, and `score=0` is the opposite (a fully white screenshot vs a fully black screenshot) 