### PR TITLE
Feat: add map pin proto

### DIFF
--- a/proto/decentraland/sdk/components/map_pin.proto
+++ b/proto/decentraland/sdk/components/map_pin.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1097;
+
+message PBMapPin {
+  decentraland.common.Vector2 position = 1;
+  string icon_sprite = 2;
+  float icon_size = 3;
+  string title = 4;
+  string description = 5;
+}

--- a/proto/decentraland/sdk/components/map_pin.proto
+++ b/proto/decentraland/sdk/components/map_pin.proto
@@ -5,6 +5,8 @@ import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/texture.proto";
 option (common.ecs_component_id) = 1097;
 
+// @deprecated
+// Used internally for the game orchestrator PX, not exposed in the SDK
 message PBMapPin {
   decentraland.common.Vector2 position = 1;
   optional decentraland.common.TextureUnion texture = 2;

--- a/proto/decentraland/sdk/components/map_pin.proto
+++ b/proto/decentraland/sdk/components/map_pin.proto
@@ -2,11 +2,12 @@ syntax = "proto3";
 package decentraland.sdk.components;
 import "decentraland/common/vectors.proto";
 import "decentraland/sdk/components/common/id.proto";
+import "decentraland/common/texture.proto";
 option (common.ecs_component_id) = 1097;
 
 message PBMapPin {
   decentraland.common.Vector2 position = 1;
-  string icon_sprite = 2;
+  optional decentraland.common.TextureUnion texture = 2;
   float icon_size = 3;
   string title = 4;
   string description = 5;


### PR DESCRIPTION
This PR adds support for the map pin component used internally for the exploration quests