### PR TITLE
chore: remove the usage of `reserved "key"`

### DIFF
--- a/proto/decentraland/realm/about.proto
+++ b/proto/decentraland/realm/about.proto
@@ -84,8 +84,12 @@ message AboutResponse {
     uint32 network_id = 2;
     repeated string global_scenes_urn = 3;
     repeated string scenes_urn = 4;
+
+    // The name "minimap" can't be used in this message
+    // The reserved keyword is not working for all the toolset we have, so in the meanwhile it keeps commented
     reserved 5;
-    reserved "minimap";
+    // reserved "minimap";
+
     optional SkyboxConfiguration skybox = 6;
 
     // A content server to be used to load the parcels around the user. Uses the POST /entities/active endpoint

--- a/proto/decentraland/realm/about.proto
+++ b/proto/decentraland/realm/about.proto
@@ -14,13 +14,14 @@ message AboutResponse {
   bool accepting_users = 7;
 
   // @deprecated This message was never used but it's still here for compatibility reasons
+  // The reserved keyword is not working for all the toolset we have, so in the meanwhile it keeps commented
   message MinimapConfiguration {
     reserved 1;
-    reserved "enabled";
+    // reserved "enabled";
     reserved 2;
-    reserved "data_image";
+    // reserved "data_image";
     reserved 3;
-    reserved "estate_image";
+    // reserved "estate_image";
   }
 
   message MapConfiguration {


### PR DESCRIPTION
This "breaks" compatibility at formality-level but it doesn't at functionality-level.
The tool we use to check compatibility should support reserved keys: https://github.com/well-known-components/proto-compatibility-tool/blob/main/src/index.ts#L212