### PR TITLE
chore: move alpha_texture from PBRMaterial to UnlitMaterial

### DIFF
--- a/proto/decentraland/sdk/components/material.proto
+++ b/proto/decentraland/sdk/components/material.proto
@@ -22,6 +22,7 @@ message PBMaterial {
     optional float alpha_test = 2; // default = 0.5. range value: from 0 to 1
     optional bool cast_shadows = 3; // default =  true
     optional decentraland.common.Color4 diffuse_color = 4; // default = white;
+    optional decentraland.common.TextureUnion alpha_texture = 5; // default = null
   }
 
   message PbrMaterial {
@@ -29,7 +30,7 @@ message PBMaterial {
   
     optional float alpha_test = 2; // default = 0.5. range value: from 0 to 1
     optional bool cast_shadows = 3; // default =  true
-  
+    // @deprecated Alpha textures are no longer supported on PBRMaterial and UnlitMaterial.alphaTexture should be used instead.
     optional decentraland.common.TextureUnion alpha_texture = 4; // default = null
     optional decentraland.common.TextureUnion emissive_texture = 5; // default = null
     optional decentraland.common.TextureUnion bump_texture = 6; // default = null


### PR DESCRIPTION
Addresses the protocol part of [issue #240](https://github.com/decentraland/creator-hub/issues/240)

Related PRs:
E@: https://github.com/decentraland/unity-explorer/pull/2482
SDK: https://github.com/decentraland/js-sdk-toolchain/pull/1019