### PR TITLE
feat: avatar_target param addition in movePlayerTo

### DIFF
--- a/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -6,6 +6,7 @@ import "decentraland/common/vectors.proto";
 message MovePlayerToRequest {
   decentraland.common.Vector3 new_relative_position = 1;
   optional decentraland.common.Vector3 camera_target = 2;
+  optional decentraland.common.Vector3 avatar_target = 3;
 }
 
 message TeleportToRequest {


### PR DESCRIPTION
Added avatar_target param in movePlayerTo() according to [ADR: 257](https://github.com/decentraland/adr/blob/main/content/ADR-257-avatar-rotation.md).

Related PRs:
* https://github.com/decentraland/js-sdk-toolchain/pull/1073
* https://github.com/decentraland/unity-explorer/pull/3328