### PR TITLE
feat: Include is friend when asking for privacy settings

### DIFF
--- a/proto/decentraland/social_service/v2/social_service_v2.proto
+++ b/proto/decentraland/social_service/v2/social_service_v2.proto
@@ -257,6 +257,7 @@ message GetPrivateMessagesSettingsResponse {
   message PrivateMessagesSettings {
     User user = 1;
     PrivateMessagePrivacySetting private_messages_privacy = 2;
+    bool is_friend = 3;
   }
 
   message Ok {


### PR DESCRIPTION
This PR adds the `isFriend` property to the privacy settings response so the client can decide wether it can message someone or not if they have the only friends setting on.