### PR TITLE
feat: Add optional from in chat

### DIFF
--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -101,6 +101,7 @@ message ProfileResponse {
 message Chat {
   string message = 1;
   double timestamp = 2;
+  optional string from = 3;
 }
 
 message Scene {

--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -102,7 +102,8 @@ message Chat {
   string message = 1;
   double timestamp = 2;
 
-  // Extension: optional forwarded_from to identify the original sender of the message
+  // Extension: optional forwarded_from to identify the original sender when
+  // messages are forwarded through a SFU
   optional string forwarded_from = 3;
 }
 

--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -101,7 +101,9 @@ message ProfileResponse {
 message Chat {
   string message = 1;
   double timestamp = 2;
-  optional string from = 3;
+
+  // Extension: optional forwarded_from to identify the original sender of the message
+  optional string forwarded_from = 3;
 }
 
 message Scene {

--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -103,7 +103,7 @@ message Chat {
   double timestamp = 2;
 
   // Extension: optional forwarded_from to identify the original sender when
-  // messages are forwarded through a SFU
+  // messages are forwarded through an SFU
   optional string forwarded_from = 3;
 }
 


### PR DESCRIPTION
This PR introduces a new optional from field in the Chat message defined in our protobuf protocol.

🎯 Purpose

As part of the Communities chat implementation, we’re introducing an intermediate actor — the Comms Message SFU — responsible for receiving messages from the client, validating the sender, resolving the list of community members, and then forwarding the message to the correct recipients.

Because the message is re-broadcasted by the SFU (instead of the original sender), the receiving clients would otherwise see the SFU as the sender. To preserve the identity of the original author, we’re adding the from field, allowing clients to properly render the original sender in the chat UI.

🧱 Changes
- Add optional from field to the Chat protobuf message

This change is backward-compatible, as the new field is optional and won’t affect existing message flows outside the Communities context.