### PR TITLE
feat: GltfNodeModifiers component

### DIFF
--- a/proto/decentraland/sdk/components/gltf_node_modifiers.proto
+++ b/proto/decentraland/sdk/components/gltf_node_modifiers.proto
@@ -9,17 +9,17 @@ option (common.ecs_component_id) = 1099;
 
 // GltfNodeModifiers component is to be used attached to entities that have the GltfContainer component.
 //
-// This allows to override either the Material or the casting shadows behaviour of the target GLTF node.
+// This allows to override either the Material or the Casting Shadows behaviour of the target GLTF Node.
 // 
 // * If the 'path' of the first modifier in the collection is an empty string: the configuration will
-// affect all of the GLTF nodes altogether (as a global modifier).
-// * Otherwise, for the modifies whose 'path' is found in the GLTF hierarchy, the modifier will affect only
-// the target nodes.
+// affect all of the GLTF Nodes (as a global modifier).
+// * Otherwise, for the modifiers whose 'path' is found in the GLTF hierarchy, the modifier will affect only
+// the target Nodes.
 message PBGltfNodeModifiers {
   message GltfNodeModifier {
     string path = 1; // The GLTF hierarchy path of the target Node to be affected
     optional bool cast_shadows = 2; // The casting shadows enabled override
-    optional PBMaterial material = 3; // The Material that will be overridden on the target node
+    optional PBMaterial material = 3; // The Material that will be overridden on the target Node
   }
   repeated GltfNodeModifier modifiers  = 1;
 }

--- a/proto/decentraland/sdk/components/gltf_node_modifiers.proto
+++ b/proto/decentraland/sdk/components/gltf_node_modifiers.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+import "decentraland/sdk/components/material.proto";
+
+option (common.ecs_component_id) = 1099;
+
+message PBGltfNodeModifiers {
+  message GltfNodeModifier {
+    string path = 1;
+    optional bool override_shadows = 2;
+    optional PBMaterial material = 3;
+  }
+  repeated GltfNodeModifier modifiers  = 1;
+}

--- a/proto/decentraland/sdk/components/gltf_node_modifiers.proto
+++ b/proto/decentraland/sdk/components/gltf_node_modifiers.proto
@@ -10,7 +10,7 @@ option (common.ecs_component_id) = 1099;
 message PBGltfNodeModifiers {
   message GltfNodeModifier {
     string path = 1;
-    optional bool override_shadows = 2;
+    optional bool cast_shadows = 2;
     optional PBMaterial material = 3;
   }
   repeated GltfNodeModifier modifiers  = 1;

--- a/proto/decentraland/sdk/components/gltf_node_modifiers.proto
+++ b/proto/decentraland/sdk/components/gltf_node_modifiers.proto
@@ -7,11 +7,19 @@ import "decentraland/sdk/components/material.proto";
 
 option (common.ecs_component_id) = 1099;
 
+// GltfNodeModifiers component is to be used attached to entities that have the GltfContainer component.
+//
+// This allows to override either the Material or the casting shadows behaviour of the target GLTF node.
+// 
+// * If the 'path' of the first modifier in the collection is an empty string: the configuration will
+// affect all of the GLTF nodes altogether (as a global modifier).
+// * Otherwise, for the modifies whose 'path' is found in the GLTF hierarchy, the modifier will affect only
+// the target nodes.
 message PBGltfNodeModifiers {
   message GltfNodeModifier {
-    string path = 1;
-    optional bool cast_shadows = 2;
-    optional PBMaterial material = 3;
+    string path = 1; // The GLTF hierarchy path of the target Node to be affected
+    optional bool cast_shadows = 2; // The casting shadows enabled override
+    optional PBMaterial material = 3; // The Material that will be overridden on the target node
   }
   repeated GltfNodeModifier modifiers  = 1;
 }

--- a/public/sdk-components.proto
+++ b/public/sdk-components.proto
@@ -15,6 +15,7 @@ import public "decentraland/sdk/components/camera_mode_area.proto";
 import public "decentraland/sdk/components/camera_mode.proto";
 import public "decentraland/sdk/components/engine_info.proto";
 import public "decentraland/sdk/components/gltf_container.proto";
+import public "decentraland/sdk/components/gltf_node_modifiers.proto";
 import public "decentraland/sdk/components/gltf_container_loading_state.proto";
 import public "decentraland/sdk/components/material.proto";
 import public "decentraland/sdk/components/mesh_collider.proto";


### PR DESCRIPTION
Add new `GltfNodeModifiers` component structure.

Related PRs:
* https://github.com/decentraland/js-sdk-toolchain/pull/1156
* https://github.com/decentraland/protocol/pull/286
* https://github.com/decentraland/js-sdk-toolchain/pull/1158
* https://github.com/decentraland/sdk7-test-scenes/pull/32
* https://github.com/decentraland/unity-explorer/pull/4754