### PR TITLE
emote timestamp as not-breaking change

### DIFF
--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -68,8 +68,9 @@ message MovementCompressed {
 }
 
 message PlayerEmote {
-  float timestamp = 1;
+  uint32 incremental_id = 1;
   string urn = 2;
+  float timestamp = 3;
 }
 
 message SceneEmote {


### PR DESCRIPTION
moved emote message  `timestamp `as not-breaking change (bringing back `incremental_id`)