### PR TITLE
feat: trigger area components

### DIFF
--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -59,4 +59,5 @@ enum ColliderLayer {
   CL_CUSTOM6 = 8192;
   CL_CUSTOM7 = 16384;
   CL_CUSTOM8 = 32768;
+  CL_PLAYER = 65536;
 }

--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -45,7 +45,7 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_RESERVED1 = 4;
+  CL_PLAYER = 4;
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;
@@ -59,5 +59,4 @@ enum ColliderLayer {
   CL_CUSTOM6 = 8192;
   CL_CUSTOM7 = 16384;
   CL_CUSTOM8 = 32768;
-  CL_PLAYER = 65536;
 }

--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -42,9 +42,11 @@ message PBMeshCollider {
 
 // ColliderLayer determines the kind of collision to detect, in OR-able bit flag form.
 enum ColliderLayer {
+  option allow_alias = true;
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
+  CL_RESERVED1 = 4 [deprecated = true];
   CL_PLAYER = 4;         // layer corresponding to any player avatar
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;

--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -42,11 +42,9 @@ message PBMeshCollider {
 
 // ColliderLayer determines the kind of collision to detect, in OR-able bit flag form.
 enum ColliderLayer {
-  option allow_alias = true;
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_RESERVED1 = 4 [deprecated = true];
   CL_PLAYER = 4;         // layer corresponding to any player avatar
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;

--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -45,7 +45,7 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_PLAYER = 4;
+  CL_PLAYER = 4;         // layer corresponding to any player avatar
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;

--- a/proto/decentraland/sdk/components/trigger_area.proto
+++ b/proto/decentraland/sdk/components/trigger_area.proto
@@ -13,11 +13,11 @@ option (common.ecs_component_id) = 1060;
 //
 // The area size and rotation is defined by the Entity's Transform.
 message PBTriggerArea {
-  optional MeshType mesh = 1;         // default: MT_BOX
+  optional TriggerAreaMeshType mesh = 1;         // default: MT_BOX
   optional uint32 collision_mask = 2; // default: CL_PLAYER
 }
 
-enum MeshType {
-  MT_BOX = 0;
-  MT_SPHERE = 1;
+enum TriggerAreaMeshType {
+  TAMT_BOX = 0;
+  TAMT_SPHERE = 1;
 }

--- a/proto/decentraland/sdk/components/trigger_area.proto
+++ b/proto/decentraland/sdk/components/trigger_area.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1060;
+
+// The PBTriggerArea component is used to raise collision triggering events (through the TriggerAreaResult component)
+// when entities enter this component's defined area.
+//
+// ADR: https://github.com/decentraland/adr/blob/2b30a5e2b4f359a7c22a68fb827db282f6e5f887/content/ADR-258-trigger-areas.md
+//
+// The area size and rotation is defined by the Entity's Transform.
+message PBTriggerArea {
+  optional MeshType mesh = 1;         // default: MT_BOX
+  optional uint32 collision_mask = 2; // default: CL_PLAYER
+}
+
+enum MeshType {
+  MT_BOX = 0;
+  MT_SPHERE = 1;
+}

--- a/proto/decentraland/sdk/components/trigger_area_result.proto
+++ b/proto/decentraland/sdk/components/trigger_area_result.proto
@@ -24,6 +24,7 @@ message PBTriggerAreaResult {
   decentraland.common.Quaternion triggered_entity_rotation = 3; // The rotation of the triggered entity at the time of the trigger
   TriggerAreaEventType event_type = 4;                          // The state of the trigger event (ENTER, STAY, EXIT)
   uint32 timestamp = 5;                                         // The timestamp of the trigger event
+  Trigger trigger = 6;
 }
 
 enum TriggerAreaEventType {

--- a/proto/decentraland/sdk/components/trigger_area_result.proto
+++ b/proto/decentraland/sdk/components/trigger_area_result.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1061;
+
+// The PBTriggerAreaResult component is used to transport the trigger collision event data for the PBTriggerArea component.
+// ADR: https://github.com/decentraland/adr/blob/2b30a5e2b4f359a7c22a68fb827db282f6e5f887/content/ADR-258-trigger-areas.md
+message PBTriggerAreaResult {
+  // Trigger data object
+  message Trigger {
+    uint32 entity = 1;                                          // The entity that triggered the Trigger Area
+    uint32 layer = 2;                                           // The collision layer of the entity that triggered the Trigger Area
+    decentraland.common.Vector3 position = 3;                   // The position of the entity that triggered the trigger
+    decentraland.common.Quaternion rotation = 4;                // The rotation of the entity that triggered the trigger
+    decentraland.common.Vector3 scale = 5;                      // The scale of the entity that triggered the trigger
+  }
+  
+  uint32 triggered_entity = 1;                                  // The entity that was triggered (this is the entity that owns the trigger area)
+  decentraland.common.Vector3 triggered_entity_position = 2;    // The position of the triggered entity at the time of the trigger
+  decentraland.common.Quaternion triggered_entity_rotation = 3; // The rotation of the triggered entity at the time of the trigger
+  TriggerAreaEventType event_type = 4;                          // The state of the trigger event (ENTER, STAY, EXIT)
+  uint32 timestamp = 5;                                         // The timestamp of the trigger event
+}
+
+enum TriggerAreaEventType {
+  TAET_ENTER = 0;
+  TAET_STAY = 1;
+  TAET_EXIT = 2;
+}

--- a/proto/decentraland/sdk/components/trigger_area_result.proto
+++ b/proto/decentraland/sdk/components/trigger_area_result.proto
@@ -13,7 +13,7 @@ message PBTriggerAreaResult {
   // Trigger data object
   message Trigger {
     uint32 entity = 1;                                          // The entity that triggered the Trigger Area
-    uint32 layer = 2;                                           // The collision layer of the entity that triggered the Trigger Area
+    uint32 layers = 2;                                          // The collision layermask of the entity that triggered the Trigger Area
     decentraland.common.Vector3 position = 3;                   // The position of the entity that triggered the trigger
     decentraland.common.Quaternion rotation = 4;                // The rotation of the entity that triggered the trigger
     decentraland.common.Vector3 scale = 5;                      // The scale of the entity that triggered the trigger


### PR DESCRIPTION
`TriggerArea` and `TriggerAreaResult` messages implementation for the new components in the SDK.

Related PRs:
- https://github.com/decentraland/protocol/pull/307
- https://github.com/decentraland/js-sdk-toolchain/pull/1210
- https://github.com/decentraland/unity-explorer/pull/5244
- https://github.com/decentraland/sdk7-test-scenes/pull/34