### PR TITLE
Added social emote outcome index

### DIFF
--- a/proto/decentraland/sdk/components/avatar_emote_command.proto
+++ b/proto/decentraland/sdk/components/avatar_emote_command.proto
@@ -10,4 +10,5 @@ message PBAvatarEmoteCommand {
   string emote_urn = 1;
   bool loop = 2;
   uint32 timestamp = 3;          // monotonic counter
+  uint32 social_emote_outcome = 4; // -1 means it does not use an outcome animation
 }


### PR DESCRIPTION
Needed to develop this shape: https://www.notion.so/decentraland/Social-Emotes-22d5f41146a5809dbe8ff69a9682f353

When the outcome is > -1 it means the avatar started an animation that uses the configuration in one of the outcomes defined in the emote's metadata.