### PR TITLE
feat: non pointer interaction (#353)

### DIFF
--- a/proto/decentraland/sdk/components/common/input_action.proto
+++ b/proto/decentraland/sdk/components/common/input_action.proto
@@ -25,4 +25,11 @@ enum PointerEventType {
   PET_DOWN = 1;
   PET_HOVER_ENTER = 2;
   PET_HOVER_LEAVE = 3;
+  PET_PROXIMITY_ENTER = 4;
+  PET_PROXIMITY_LEAVE = 5;
+}
+
+enum InteractionType {
+  CURSOR = 0;
+  PROXIMITY = 1;
 }

--- a/proto/decentraland/sdk/components/pointer_events.proto
+++ b/proto/decentraland/sdk/components/pointer_events.proto
@@ -51,11 +51,13 @@ message PBPointerEvents {
     optional bool show_feedback = 4;        // enable or disable hover text and highlight (default true)
     optional bool show_highlight = 5;       // enable or disable hover highlight (default true)
     optional float max_player_distance = 6; // range of interaction from the avatar's position (default 0)
+    optional uint32 priority = 7;           // resolution order when multiple events overlap, higher wins (default 0)
   }
 
   message Entry {
     common.PointerEventType event_type = 1; // the kind of interaction to detect
     Info event_info = 2;             // additional configuration for this detection
+    optional common.InteractionType interaction_type = 3; // the type of interaction source (default 0 == CURSOR)
   }
 
   repeated Entry pointer_events = 1; // the list of relevant events to detect


### PR DESCRIPTION
- add InteractionType enum to input_action.proto
- Added optional priority field to PBPointerEvents for resolution order of overlapping events.
- Introduced optional interaction_type field in Entry message to specify the type of interaction source.
- Add PET_PROXIMITY_ENTER and PET_PROXIMITY_LEAVE to PointerEventType enum