### PR TITLE
feat: particle system component (experimental)

### DIFF
--- a/proto/decentraland/common/colors.proto
+++ b/proto/decentraland/common/colors.proto
@@ -13,3 +13,9 @@ message Color4 {
   float b = 3;
   float a = 4;
 }
+
+// A range of Color4 values. Randomized or lerped between start and end.
+message ColorRange {
+  Color4 start = 1;
+  Color4 end = 2;
+}

--- a/proto/decentraland/common/floats.proto
+++ b/proto/decentraland/common/floats.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package decentraland.common;
+
+// A range of float values. Randomized or lerped between start and end.
+message FloatRange {
+  float start = 1;
+  float end = 2;
+}

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -73,9 +73,7 @@ message PBParticleSystem {
   message SpriteSheetAnimation {
     uint32 tiles_x = 1;      // Number of columns in the sprite sheet.
     uint32 tiles_y = 2;      // Number of rows in the sprite sheet.
-    uint32 start_frame = 3;  // First frame index (inclusive).
-    uint32 end_frame = 4;    // Last frame index (inclusive). 0 = use all frames.
-    optional float frames_per_second = 5; // default = 30. Playback speed in frames per second.
+    optional float frames_per_second = 3; // default = 30. Playback speed in frames per second.
   }
 
   // Clamps particle speed over lifetime.

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -26,8 +26,8 @@ message PBParticleSystem {
   optional decentraland.common.FloatRange size_over_time = 8;   // default = {1, 1}. Particle size lerped from start to end over its lifetime.
 
   // --- Rotation ---
-  optional decentraland.common.FloatRange initial_rotation = 9;      // default = {0, 0}. Initial rotation in degrees, randomized between start and end.
-  optional decentraland.common.FloatRange rotation_over_time = 10;   // default = {0, 0}. Angular velocity in degrees/sec, lerped over lifetime.
+  optional decentraland.common.Quaternion initial_rotation = 9;      // default = identity (0,0,0,1). 3D start rotation for each particle.
+  optional decentraland.common.Quaternion rotation_over_time = 10;   // default = identity (0,0,0,1). Per-axis angular velocity as quaternion; converted to Euler XYZ.
   optional bool face_travel_direction = 28; // default = false. Particles orient along their velocity direction.
 
   // --- Color ---
@@ -40,7 +40,7 @@ message PBParticleSystem {
   // --- Rendering ---
   optional decentraland.common.Texture texture = 14; // Particle texture. default = null (plain white quad).
   optional BlendMode blend_mode = 15;                // default = PSB_ALPHA
-  reserved 16; // Reserved for future Billboard property.
+  optional bool billboard = 16;  // default = true
 
   // --- Sprite Sheet Animation ---
   optional SpriteSheetAnimation sprite_sheet = 17;

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -18,7 +18,7 @@ message PBParticleSystem {
   optional float lifetime = 4;          // default = 5. Particle lifetime in seconds.
 
   // --- Motion ---
-  optional float gravity = 5;           // default = 0. Unity gravity modifier (multiplier of Physics.gravity).
+  optional float gravity = 5;           // default = 0. Multiplier of Explorer's physics engine Gravity (normally -9.81)
   optional decentraland.common.Vector3 additional_force = 6; // Constant force vector applied to each particle (world space).
 
   // --- Size ---

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package decentraland.sdk.components;
 
 import "decentraland/common/colors.proto";
+import "decentraland/common/floats.proto";
 import "decentraland/common/texture.proto";
 import "decentraland/common/vectors.proto";
 import "decentraland/sdk/components/common/id.proto";
@@ -21,20 +22,20 @@ message PBParticleSystem {
   optional decentraland.common.Vector3 additional_force = 6; // Constant force vector applied to each particle (world space).
 
   // --- Size ---
-  optional FloatRange initial_size = 7;     // default = {1, 1}. Particle size at spawn.
-  optional FloatRange size_over_time = 8;   // default = {1, 1}. Particle size lerped from start to end over its lifetime.
+  optional decentraland.common.FloatRange initial_size = 7;     // default = {1, 1}. Particle size at spawn.
+  optional decentraland.common.FloatRange size_over_time = 8;   // default = {1, 1}. Particle size lerped from start to end over its lifetime.
 
   // --- Rotation ---
-  optional FloatRange initial_rotation = 9;      // default = {0, 0}. Initial rotation in degrees, randomized between start and end.
-  optional FloatRange rotation_over_time = 10;   // default = {0, 0}. Angular velocity in degrees/sec, lerped over lifetime.
+  optional decentraland.common.FloatRange initial_rotation = 9;      // default = {0, 0}. Initial rotation in degrees, randomized between start and end.
+  optional decentraland.common.FloatRange rotation_over_time = 10;   // default = {0, 0}. Angular velocity in degrees/sec, lerped over lifetime.
   optional bool face_travel_direction = 28; // default = false. Particles orient along their velocity direction.
 
   // --- Color ---
-  optional ColorRange initial_color = 11;    // default = {white, white}. Particle color at spawn, randomized between start and end.
-  optional ColorRange color_over_time = 12;  // default = {white, white}. Particle color lerped from start to end over its lifetime.
+  optional decentraland.common.ColorRange initial_color = 11;    // default = {white, white}. Particle color at spawn, randomized between start and end.
+  optional decentraland.common.ColorRange color_over_time = 12;  // default = {white, white}. Particle color lerped from start to end over its lifetime.
 
   // --- Velocity ---
-  optional FloatRange initial_velocity_speed = 13; // default = {1, 1}. Initial speed in m/s, randomized between start and end.
+  optional decentraland.common.FloatRange initial_velocity_speed = 13; // default = {1, 1}. Initial speed in m/s, randomized between start and end.
 
   // --- Rendering ---
   optional decentraland.common.Texture texture = 14; // Particle texture. default = null (plain white quad).
@@ -62,21 +63,11 @@ message PBParticleSystem {
 
   // --- Playback ---
   optional PlaybackState playback_state = 22; // default = PS_PLAYING
-  optional uint32 restart_count = 23;         // Increment to trigger a restart (stop+clear+play). LWW-safe restart signal.
+
+  // --- Emission Bursts ---
+  repeated Burst bursts = 29;
 
   // ---- Nested types ----
-
-  // A range of float values. Randomized or lerped between start and end.
-  message FloatRange {
-    float start = 1;
-    float end = 2;
-  }
-
-  // A range of Color4 values. Randomized or lerped between start and end.
-  message ColorRange {
-    decentraland.common.Color4 start = 1;
-    decentraland.common.Color4 end = 2;
-  }
 
   // Sprite sheet (texture atlas) animation settings.
   message SpriteSheetAnimation {
@@ -110,6 +101,15 @@ message PBParticleSystem {
   // Emitter spawns particles from the surface or volume of a box.
   message Box {
     optional decentraland.common.Vector3 size = 1; // default = {1, 1, 1}
+  }
+
+  // Emission burst configuration.
+  message Burst {
+    float time = 1;                // Seconds from start of cycle.
+    uint32 count = 2;             // Particles to emit.
+    optional int32 cycles = 3;    // default = 1. Repeat count (0 = infinite).
+    optional float interval = 4;  // default = 0.01. Seconds between cycles.
+    optional float probability = 5; // default = 1.0. Emission chance [0,1].
   }
 
   enum BlendMode {

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -27,6 +27,7 @@ message PBParticleSystem {
   // --- Rotation ---
   optional FloatRange initial_rotation = 9;      // default = {0, 0}. Initial rotation in degrees, randomized between start and end.
   optional FloatRange rotation_over_time = 10;   // default = {0, 0}. Angular velocity in degrees/sec, lerped over lifetime.
+  optional bool face_travel_direction = 28; // default = false. Particles orient along their velocity direction.
 
   // --- Color ---
   optional ColorRange initial_color = 11;    // default = {white, white}. Particle color at spawn, randomized between start and end.
@@ -38,7 +39,7 @@ message PBParticleSystem {
   // --- Rendering ---
   optional decentraland.common.Texture texture = 14; // Particle texture. default = null (plain white quad).
   optional BlendMode blend_mode = 15;                // default = PSB_ALPHA
-  optional bool billboard = 16;                      // default = true. Particles always face the camera.
+  reserved 16; // Reserved for future Billboard property.
 
   // --- Sprite Sheet Animation ---
   optional SpriteSheetAnimation sprite_sheet = 17;

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -54,6 +54,7 @@ message PBParticleSystem {
   // --- Simulation ---
   optional bool loop = 24;     // default = true. Loop the emission cycle.
   optional bool prewarm = 25;  // default = false. Start as if already simulated for one full loop cycle. Requires loop = true.
+  optional SimulationSpace simulation_space = 27; // default = PSS_LOCAL. Controls whether particles simulate in local or world space.
 
   // --- Limit Velocity Over Lifetime ---
   optional LimitVelocity limit_velocity = 26; // Clamps particle speed over its lifetime.
@@ -82,7 +83,7 @@ message PBParticleSystem {
     uint32 tiles_y = 2;      // Number of rows in the sprite sheet.
     uint32 start_frame = 3;  // First frame index (inclusive).
     uint32 end_frame = 4;    // Last frame index (inclusive). 0 = use all frames.
-    optional float cycles_per_lifetime = 5; // default = 1. How many animation cycles to play over a particle's lifetime.
+    optional float frames_per_second = 5; // default = 30. Playback speed in frames per second.
   }
 
   // Clamps particle speed over lifetime.
@@ -120,5 +121,10 @@ message PBParticleSystem {
     PS_PLAYING = 0; // Particle system is emitting and simulating.
     PS_PAUSED = 1;  // Simulation is frozen; no new particles are emitted.
     PS_STOPPED = 2; // Simulation stopped and existing particles cleared.
+  }
+
+  enum SimulationSpace {
+    PSS_LOCAL = 0; // Particles move with the entity transform.
+    PSS_WORLD = 1; // Particles stay in world position after emission.
   }
 }

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/colors.proto";
+import "decentraland/common/texture.proto";
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1217;
+
+message PBParticleSystem {
+  // --- Emission ---
+  optional bool active = 1;              // default = true
+  optional float rate = 2;              // default = 10. Particles emitted per second.
+  optional uint32 max_particles = 3;    // default = 1000. Maximum number of live particles.
+  optional float lifetime = 4;          // default = 5. Particle lifetime in seconds.
+
+  // --- Motion ---
+  optional float gravity = 5;           // default = 0. Unity gravity modifier (multiplier of Physics.gravity).
+  optional decentraland.common.Vector3 additional_force = 6; // Constant force vector applied to each particle (world space).
+
+  // --- Size ---
+  optional FloatRange initial_size = 7;     // default = {1, 1}. Particle size at spawn.
+  optional FloatRange size_over_time = 8;   // default = {1, 1}. Particle size lerped from start to end over its lifetime.
+
+  // --- Rotation ---
+  optional FloatRange initial_rotation = 9;      // default = {0, 0}. Initial rotation in degrees, randomized between start and end.
+  optional FloatRange rotation_over_time = 10;   // default = {0, 0}. Angular velocity in degrees/sec, lerped over lifetime.
+
+  // --- Color ---
+  optional ColorRange initial_color = 11;    // default = {white, white}. Particle color at spawn, randomized between start and end.
+  optional ColorRange color_over_time = 12;  // default = {white, white}. Particle color lerped from start to end over its lifetime.
+
+  // --- Velocity ---
+  optional FloatRange initial_velocity_speed = 13; // default = {1, 1}. Initial speed in m/s, randomized between start and end.
+
+  // --- Rendering ---
+  optional decentraland.common.Texture texture = 14; // Particle texture. default = null (plain white quad).
+  optional BlendMode blend_mode = 15;                // default = PSB_ALPHA
+  optional bool billboard = 16;                      // default = true. Particles always face the camera.
+
+  // --- Sprite Sheet Animation ---
+  optional SpriteSheetAnimation sprite_sheet = 17;
+
+  // --- Emitter Shape ---
+  oneof shape {
+    Point point = 18;
+    Sphere sphere = 19;
+    Cone cone = 20;
+    Box box = 21;
+  }
+
+  // --- Playback ---
+  optional PlaybackState playback_state = 22; // default = PS_PLAYING
+  optional uint32 restart_count = 23;         // Increment to trigger a restart (stop+clear+play). LWW-safe restart signal.
+
+  // ---- Nested types ----
+
+  // A range of float values. Randomized or lerped between start and end.
+  message FloatRange {
+    float start = 1;
+    float end = 2;
+  }
+
+  // A range of Color4 values. Randomized or lerped between start and end.
+  message ColorRange {
+    decentraland.common.Color4 start = 1;
+    decentraland.common.Color4 end = 2;
+  }
+
+  // Sprite sheet (texture atlas) animation settings.
+  message SpriteSheetAnimation {
+    uint32 tiles_x = 1;      // Number of columns in the sprite sheet.
+    uint32 tiles_y = 2;      // Number of rows in the sprite sheet.
+    uint32 start_frame = 3;  // First frame index (inclusive).
+    uint32 end_frame = 4;    // Last frame index (inclusive). 0 = use all frames.
+    optional float cycles_per_lifetime = 5; // default = 1. How many animation cycles to play over a particle's lifetime.
+  }
+
+  // Emitter spawns particles from a single point.
+  message Point {}
+
+  // Emitter spawns particles from the surface or volume of a sphere.
+  message Sphere {
+    optional float radius = 1; // default = 1
+  }
+
+  // Emitter spawns particles from the base of a cone and projects them outward.
+  message Cone {
+    optional float angle = 1;  // default = 25. Half-angle of the cone in degrees.
+    optional float radius = 2; // default = 1. Base radius in meters.
+  }
+
+  // Emitter spawns particles from the surface or volume of a box.
+  message Box {
+    optional decentraland.common.Vector3 size = 1; // default = {1, 1, 1}
+  }
+
+  enum BlendMode {
+    PSB_ALPHA = 0;     // Standard alpha transparency.
+    PSB_ADD = 1;       // Additive blending (brightens underlying pixels).
+    PSB_MULTIPLY = 2;  // Multiply blending (darkens underlying pixels).
+  }
+
+  enum PlaybackState {
+    PS_PLAYING = 0; // Particle system is emitting and simulating.
+    PS_PAUSED = 1;  // Simulation is frozen; no new particles are emitted.
+    PS_STOPPED = 2; // Simulation stopped and existing particles cleared.
+  }
+}

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -51,6 +51,13 @@ message PBParticleSystem {
     Box box = 21;
   }
 
+  // --- Simulation ---
+  optional bool loop = 24;     // default = true. Loop the emission cycle.
+  optional bool prewarm = 25;  // default = false. Start as if already simulated for one full loop cycle. Requires loop = true.
+
+  // --- Limit Velocity Over Lifetime ---
+  optional LimitVelocity limit_velocity = 26; // Clamps particle speed over its lifetime.
+
   // --- Playback ---
   optional PlaybackState playback_state = 22; // default = PS_PLAYING
   optional uint32 restart_count = 23;         // Increment to trigger a restart (stop+clear+play). LWW-safe restart signal.
@@ -76,6 +83,12 @@ message PBParticleSystem {
     uint32 start_frame = 3;  // First frame index (inclusive).
     uint32 end_frame = 4;    // Last frame index (inclusive). 0 = use all frames.
     optional float cycles_per_lifetime = 5; // default = 1. How many animation cycles to play over a particle's lifetime.
+  }
+
+  // Clamps particle speed over lifetime.
+  message LimitVelocity {
+    float speed = 1;            // Maximum particle speed (m/s).
+    optional float dampen = 2;  // default = 1. Fraction (0–1) of excess velocity removed per frame. 1 = hard clamp.
   }
 
   // Emitter spawns particles from a single point.

--- a/public/sdk-components.proto
+++ b/public/sdk-components.proto
@@ -21,6 +21,7 @@ import public "decentraland/sdk/components/material.proto";
 import public "decentraland/sdk/components/mesh_collider.proto";
 import public "decentraland/sdk/components/mesh_renderer.proto";
 import public "decentraland/sdk/components/nft_shape.proto";
+import public "decentraland/sdk/components/particle_system.proto";
 import public "decentraland/sdk/components/player_identity_data.proto";
 import public "decentraland/sdk/components/pointer_events_result.proto";
 import public "decentraland/sdk/components/pointer_events.proto";


### PR DESCRIPTION
# ParticleSystem Component

Component ID: `1217` | CRDT type: Last-Write-Win (LWW)

The `ParticleSystem` component attaches a particle emitter to an entity. Particles are spawned from the entity's position according to a configurable emitter shape and evolve over their lifetime through size, color, rotation, and velocity changes.

---

## Properties

### Emission

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `active` | `bool` | `true` | Enables or disables particle emission. When `false`, no new particles spawn but existing ones continue their lifetime. |
| `rate` | `float` | `10` | Number of particles emitted per second (continuous emission). |
| `maxParticles` | `uint32` | `1000` | Maximum number of particles alive at the same time. Once the limit is reached, new particles are not spawned until existing ones expire. |
| `lifetime` | `float` | `5` | Lifetime of each particle in seconds. After this duration the particle is removed. |
| `bursts` | `Burst[]` | `[]` | List of burst emission events (see "Burst" below). |

### Motion

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `gravity` | `float` | `0` | Gravity modifier. Multiplied by the environment's gravity vector. Negative values push particles upward. |
| `additionalForce` | `Vector3` | `(0,0,0)` | Constant force vector applied to each particle every frame (world space). Useful for wind or drift effects. |
| `initialVelocitySpeed` | `FloatRange` | `{1, 1}` | Initial speed in m/s. Each particle picks a random value between `start` and `end`. |
| `limitVelocity` | `LimitVelocity` | *unset* | When set, clamps each particle's speed over its lifetime (see ["LimitVelocity" below). |

### Size

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `initialSize` | `FloatRange` | `{1, 1}` | Particle size at spawn. Random between `start` and `end`. |
| `sizeOverTime` | `FloatRange` | `{1, 1}` | Size multiplier lerped from `start` to `end` over the particle's lifetime. Use `{1, 0}` to shrink to nothing. |

### Rotation

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `initialRotation` | `Quaternion` | identity `(0,0,0,1)` | 3D start rotation applied to each particle at spawn. Expressed as a quaternion; the explorer converts it to per-axis Euler angles. |
| `rotationOverTime` | `Quaternion` | identity `(0,0,0,1)` | Per-axis angular velocity over the particle's lifetime. Expressed as a quaternion; the explorer converts it to Euler angles and applies each axis independently. |
| `faceTravelDirection` | `bool` | `false` | When `true`, each particle orients itself along its velocity direction, overriding rotation settings. Useful for trails or elongated particles. |

### Color

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `initialColor` | `ColorRange` | `{white, white}` | Particle color at spawn. Each particle picks a random color between `start` and `end` (RGBA). |
| `colorOverTime` | `ColorRange` | `{white, white}` | Particle color lerped from `start` to `end` over its lifetime. The alpha channel controls fade-out. |

### Rendering

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `texture` | `Texture` | *unset (white quad)* | Texture applied to each particle. When unset, particles render as plain white quads. |
| `blendMode` | `BlendMode` | `PSB_ALPHA` | How particles blend with the background. See "BlendMode". |
| `billboard` | `bool` | `true` | When `true`, particles always face the camera. When `false`, particles use mesh rendering with local alignment, allowing 3D rotation to be visible. Combine with `initialRotation` / `rotationOverTime` for tumbling or spinning effects. |
| `spriteSheet` | `SpriteSheetAnimation` | *unset* | When set, animates the particle texture as a sprite sheet (see "SpriteSheetAnimation"). |

### Emitter Shape

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `shape` | `oneof` | Point | The emitter shape determines where and in which direction particles spawn. Exactly one of: `Point`, `Sphere`, `Cone`, or `Box`. |

### Simulation

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `playbackState` | `PlaybackState` | `PS_PLAYING` | Controls playback. See "PlaybackState". |
| `loop` | `bool` | `true` | When `true`, emission restarts after the cycle ends. |
| `prewarm` | `bool` | `false` | When `true` (and `loop` is `true`), the system starts as if one full cycle has already elapsed. Useful to avoid a visible "ramp-up" period. |
| `simulationSpace` | `SimulationSpace` | `PSS_LOCAL` | Controls whether particles move with the entity (`LOCAL`) or remain at their world position after emission (`WORLD`). See "SimulationSpace". |

---

## Nested Types

### Burst

A burst emits a fixed number of particles at a specific time within the emission cycle.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `time` | `float` | *required* | Seconds from start of cycle when the burst fires. |
| `count` | `uint32` | *required* | Number of particles to emit. |
| `cycles` | `int32` | `1` | How many times the burst repeats. `0` = infinite. |
| `interval` | `float` | `0.01` | Seconds between burst repetitions. |
| `probability` | `float` | `1.0` | Chance `[0,1]` the burst fires each cycle. |

### LimitVelocity

Clamps particle speed over lifetime.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `speed` | `float` | *required* | Maximum particle speed in m/s. |
| `dampen` | `float` | `1.0` | Fraction `[0,1]` of excess velocity removed per frame. `1` = hard clamp. |

### SpriteSheetAnimation

Animates the particle texture as a grid-based sprite sheet.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `tilesX` | `uint32` | *required* | Number of columns in the sprite sheet. |
| `tilesY` | `uint32` | *required* | Number of rows in the sprite sheet. |
| `framesPerSecond` | `float` | `30` | Animation playback speed. |

### Emitter Shapes

**Point** -- Particles spawn from the entity's origin. No configuration.

**Sphere** -- Particles spawn from the surface or volume of a sphere.
- `radius` (float, default `1`) -- Sphere radius in meters.

**Cone** -- Particles spawn from the base of a cone and project outward.
- `angle` (float, default `25`) -- Half-angle in degrees.
- `radius` (float, default `1`) -- Base radius in meters.

**Box** -- Particles spawn from the surface or volume of a box.
- `size` (Vector3, default `{1,1,1}`) -- Box dimensions.

---

## Enums

### BlendMode

| Value | Description |
|-------|-------------|
| `PSB_ALPHA` | Standard alpha transparency. |
| `PSB_ADD` | Additive blending -- brightens underlying pixels. Good for fire, sparks, magic effects. |
| `PSB_MULTIPLY` | Multiply blending -- darkens underlying pixels. Good for shadows or smoke overlays. |

### PlaybackState

| Value | Description |
|-------|-------------|
| `PS_PLAYING` | Emitting and simulating particles. |
| `PS_PAUSED` | Simulation frozen, no new particles emitted. |
| `PS_STOPPED` | Simulation stopped and all existing particles cleared. |

### SimulationSpace

| Value | Description |
|-------|-------------|
| `PSS_LOCAL` | Particles move with the entity. Moving the entity drags existing particles along. |
| `PSS_WORLD` | Particles remain at their world position after emission. Moving the entity only changes where new particles spawn. |

---

## Use Cases

### Fire embers

Rising sparks with additive blending, upward drift via negative gravity, and a fade to black.

```typescript
import { engine, Transform } from '@dcl/sdk/ecs'
import { ParticleSystem, PBParticleSystem_BlendMode } from '@dcl/sdk/ecs'
import { Color4, Vector3 } from '@dcl/sdk/math'

const fire = engine.addEntity()
Transform.create(fire, { position: Vector3.create(8, 1, 8) })

ParticleSystem.create(fire, {
  rate: 40,
  lifetime: 2,
  maxParticles: 200,
  initialSize: { start: 0.1, end: 0.3 },
  sizeOverTime: { start: 1.0, end: 0.0 },
  initialColor: {
    start: Color4.create(1, 0.6, 0.1, 1),
    end: Color4.create(1, 0.2, 0, 1)
  },
  colorOverTime: {
    start: Color4.create(1, 0.5, 0.1, 1),
    end: Color4.create(0.2, 0, 0, 0)
  },
  initialVelocitySpeed: { start: 1.5, end: 2.5 },
  gravity: -0.3,
  blendMode: PBParticleSystem_BlendMode.PSB_ADD,
  shape: ParticleSystem.Shape.Point(),
  bursts: []
})
```

### Snowfall

A wide cone emitter flipped upside-down via the entity's transform to simulate falling snow.

```typescript
import { Quaternion } from '@dcl/sdk/math'

const snow = engine.addEntity()
Transform.create(snow, {
  position: Vector3.create(8, 5, 8),
  rotation: Quaternion.fromEulerDegrees(180, 0, 0)
})

ParticleSystem.create(snow, {
  rate: 30,
  lifetime: 4,
  maxParticles: 300,
  initialSize: { start: 0.06, end: 0.14 },
  initialVelocitySpeed: { start: 2, end: 3 },
  gravity: 1.5,
  shape: ParticleSystem.Shape.Cone({ angle: 15, radius: 2 }),
  bursts: []
})
```

### Upward vortex spiral (billboard OFF + 3D rotation)

Billboard disabled so particles can tumble in 3D. Uses both `initialRotation` (tilted spawn orientation) and `rotationOverTime` (spinning over lifetime). Negative gravity and lateral force create a spiral.

```typescript
const vortex = engine.addEntity()
Transform.create(vortex, { position: Vector3.create(8, 1, 8) })

ParticleSystem.create(vortex, {
  rate: 35,
  lifetime: 3,
  maxParticles: 200,
  initialSize: { start: 0.15, end: 0.3 },
  sizeOverTime: { start: 1.0, end: 0.2 },
  initialColor: {
    start: Color4.create(0.3, 0.8, 1, 1),
    end: Color4.create(0.6, 0.2, 1, 1)
  },
  colorOverTime: {
    start: Color4.create(0.5, 0.6, 1, 0.9),
    end: Color4.create(0.8, 0.1, 1, 0)
  },
  initialVelocitySpeed: { start: 1.5, end: 3.0 },
  gravity: -0.8,
  additionalForce: Vector3.create(0.3, 0, 0),
  billboard: false,
  // ~45 degrees tilt on X axis
  initialRotation: { x: 0.3827, y: 0, z: 0, w: 0.9239 },
  // spin on Y (90 deg) + slight Z twist (30 deg)
  rotationOverTime: { x: 0.0381, y: 0.6964, z: 0.2126, w: 0.6848 },
  blendMode: PBParticleSystem_BlendMode.PSB_ADD,
  shape: ParticleSystem.Shape.Cone({ angle: 15, radius: 0.3 }),
  bursts: []
})
```

### One-shot burst explosion

No continuous emission (`rate: 0`), just a single burst of 100 particles with `loop: false`.

```typescript
const explosion = engine.addEntity()
Transform.create(explosion, { position: Vector3.create(8, 1, 8) })

ParticleSystem.create(explosion, {
  loop: false,
  rate: 0,
  lifetime: 3,
  maxParticles: 150,
  initialSize: { start: 0.1, end: 0.25 },
  sizeOverTime: { start: 1.0, end: 0.0 },
  initialVelocitySpeed: { start: 2, end: 4 },
  limitVelocity: { speed: 2, dampen: 0.6 },
  shape: ParticleSystem.Shape.Sphere({ radius: 0.5 }),
  bursts: [
    { time: 0, count: 100, cycles: 1, interval: 0.01, probability: 1.0 }
  ]
})
```

### Animated sprite sheet (campfire)

A texture atlas with a 4x3 grid of frames, played at 12 FPS per particle.

```typescript
const campfire = engine.addEntity()
Transform.create(campfire, { position: Vector3.create(8, 1, 8) })

ParticleSystem.create(campfire, {
  rate: 12,
  lifetime: 1.8,
  maxParticles: 40,
  initialSize: { start: 0.8, end: 1.4 },
  sizeOverTime: { start: 1.0, end: 0.3 },
  gravity: -0.5,
  blendMode: PBParticleSystem_BlendMode.PSB_ADD,
  texture: { src: 'assets/sprite_fire.png' },
  spriteSheet: { tilesX: 4, tilesY: 3, framesPerSecond: 12 },
  shape: ParticleSystem.Shape.Point(),
  bursts: []
})
```

### Controlling playback at runtime

Toggle between playing, paused, and stopped states using mutable access.

```typescript
import { PBParticleSystem_PlaybackState } from '@dcl/sdk/ecs'

// Pause
const ps = ParticleSystem.getMutable(entity)
ps.playbackState = PBParticleSystem_PlaybackState.PS_PAUSED

// Resume
ps.playbackState = PBParticleSystem_PlaybackState.PS_PLAYING

// Stop and clear all particles
ps.playbackState = PBParticleSystem_PlaybackState.PS_STOPPED
```

### Trail behind a moving entity (simulation space)

Using `PSS_LOCAL` means particles travel with the entity, creating a cohesive trail.

```typescript
import { PBParticleSystem_SimulationSpace } from '@dcl/sdk/ecs'

ParticleSystem.create(movingEntity, {
  rate: 40,
  lifetime: 2,
  maxParticles: 200,
  initialSize: { start: 0.1, end: 0.2 },
  sizeOverTime: { start: 1.0, end: 0.0 },
  simulationSpace: PBParticleSystem_SimulationSpace.PSS_LOCAL,
  shape: ParticleSystem.Shape.Point(),
  bursts: []
})
```

Switch to `PSS_WORLD` if you want particles to stay where they were emitted while the entity moves away.

-------------------

https://github.com/user-attachments/assets/6c745bce-0f43-4c40-b85d-cbdbc38e01db

**Related PRs:**
- https://github.com/decentraland/protocol/pull/382
- https://github.com/decentraland/js-sdk-toolchain/pull/1346
- https://github.com/decentraland/unity-explorer/pull/7350
- https://github.com/decentraland/sdk7-test-scenes/pull/55