### PR TITLE
feat: add LookAtPosition, Reaction and ChatReaction comms messages

### DIFF
--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -18,6 +18,9 @@ message Packet {
     PlayerEmote player_emote = 9;
     SceneEmote scene_emote = 10;
     MovementCompressed movement_compressed = 12;
+    LookAtPosition look_at_position = 13;
+    Reaction reaction = 14;
+    ChatReaction chat_reaction = 15;
   }
   uint32 protocol_version = 11;
 }
@@ -137,4 +140,26 @@ message Voice {
   enum VoiceCodec {
     VC_OPUS = 0;
   }
+}
+
+// Message sent to force an avatar to look at a position
+message LookAtPosition {
+  float timestamp = 1;
+  // world position
+  float position_x = 2;
+  float position_y = 3;
+  float position_z = 4;
+  string target_avatar_wallet_address = 5;
+}
+
+message Reaction {
+  int32 emoji_index = 1;
+  float timestamp = 2;
+  int32 count = 3;
+}
+
+message ChatReaction {
+  int32 emoji_index = 1;
+  string message_id = 2;
+  string address = 3;
 }


### PR DESCRIPTION
Porting LookAtPosition, Reaction and ChatReaction comms messages from experimental.

## Summary
- Add `LookAtPosition look_at_position = 13` to `Packet` oneof — force an avatar to look at a world position
- Add `Reaction reaction = 14` to `Packet` oneof — situational emoji reactions broadcast to nearby users
- Add `ChatReaction chat_reaction = 15` to `Packet` oneof — emoji reactions tied to a specific chat message
- Add `LookAtPosition` message definition (timestamp, position xyz, target wallet address)
- Add `Reaction` message definition (emoji_index, timestamp, count)
- Add `ChatReaction` message definition (emoji_index, message_id, address)

Field numbers match the experimental branch for wire compatibility.

## Related PRs
- https://github.com/decentraland/protocol/pull/376