### PR TITLE
chore: update particle system bursts property (experimental)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .DS_Store
 out-*
 proto/google
+.idea

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -66,7 +66,7 @@ message PBParticleSystem {
 
   // --- Emission Bursts ---
   reserved 29; // deprecated 'repeated Burst bursts = 29'
-  optional Bursts bursts = 30;
+  optional BurstConfiguration bursts = 30;
 
   // ---- Nested types ----
 
@@ -103,7 +103,7 @@ message PBParticleSystem {
   }
 
   // Emission burst configuration.
-  message Bursts {
+  message BurstConfiguration {
     repeated Burst values = 1;
   }
   

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -65,7 +65,8 @@ message PBParticleSystem {
   optional PlaybackState playback_state = 22; // default = PS_PLAYING
 
   // --- Emission Bursts ---
-  repeated Burst bursts = 29;
+  reserved 29; // deprecated 'repeated Burst bursts = 29'
+  optional Bursts bursts = 30;
 
   // ---- Nested types ----
 
@@ -102,6 +103,10 @@ message PBParticleSystem {
   }
 
   // Emission burst configuration.
+  message Bursts {
+    repeated Burst values = 1;
+  }
+  
   message Burst {
     float time = 1;                // Seconds from start of cycle.
     uint32 count = 2;             // Particles to emit.

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -65,8 +65,7 @@ message PBParticleSystem {
   optional PlaybackState playback_state = 22; // default = PS_PLAYING
 
   // --- Emission Bursts ---
-  reserved 29; // deprecated 'repeated Burst bursts = 29'
-  optional BurstConfiguration burst_configuration = 30;
+  optional BurstConfiguration bursts = 29;
 
   // ---- Nested types ----
 

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -66,7 +66,7 @@ message PBParticleSystem {
 
   // --- Emission Bursts ---
   reserved 29; // deprecated 'repeated Burst bursts = 29'
-  optional BurstConfiguration bursts = 30;
+  optional BurstConfiguration burstConfiguration = 30;
 
   // ---- Nested types ----
 

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -66,7 +66,7 @@ message PBParticleSystem {
 
   // --- Emission Bursts ---
   reserved 29; // deprecated 'repeated Burst bursts = 29'
-  optional BurstConfiguration burstConfiguration = 30;
+  optional BurstConfiguration burst_configuration = 30;
 
   // ---- Nested types ----
 


### PR DESCRIPTION
Replaced bursts collection with wrapper, that can be `optional` (`repeated` fields cannot).

Related PRs:
- https://github.com/decentraland/protocol/pull/386
- https://github.com/decentraland/js-sdk-toolchain/pull/1375
- https://github.com/decentraland/unity-explorer/pull/8267
- https://github.com/decentraland/sdk7-test-scenes/pull/64