### PR TITLE
feat: scene-driven movement animations

### DIFF
--- a/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/proto/decentraland/sdk/components/avatar_movement.proto
@@ -25,6 +25,7 @@ message MovementAnimation {
   bool idle = 4;                                            // true: a triggerSceneEmote may take over; false: emotes are suppressed while this animation plays
   optional float transition_seconds = 5;                    // cross-fade duration when `src` changes; defaults to 0.2 when unset. Not applied to loop/speed/idle changes.
   optional float playback_time = 6;                         // if set, the engine seeks to this position (in seconds) this frame. Clear on subsequent frames to allow normal playback. The scene can read `AvatarAnimationState.playback_time` first to decide.
+  repeated string sounds = 7;                               // scene-relative paths to audio clips (.mp3/.ogg) to play this frame on the avatar audio bus. Fire-and-forget: each listed clip plays once per frame it appears; leaving a clip set for multiple frames re-triggers it. No stop mechanism. Use `AvatarAnimationState.playback_time` to trigger sounds at the right point in the clip (e.g. foot plants).
 }
 
 // engine behaviour (uses only capsule shapecasts and GJK closest point for portability):

--- a/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/proto/decentraland/sdk/components/avatar_movement.proto
@@ -12,6 +12,19 @@ message PBAvatarMovement {
   float orientation = 2;                                    // 0-360, we don't allow pitch/roll
   optional decentraland.common.Vector3 ground_direction = 3;
   optional bool walk_success = 4;                           // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
+  optional MovementAnimation animation = 5;                 // if set, the engine plays this animation instead of selecting one from velocity heuristics
+}
+
+// Describes the animation the movement scene wants the avatar to play.
+// One GLB = one clip (following the scene-emote convention: single clip, or a clip named with `_Avatar` suffix).
+// When absent the engine falls back to its built-in velocity-based selection (walk/run/jump/idle).
+message MovementAnimation {
+  string src = 1;                                           // scene-relative path to the gltf/glb asset (resolved via the scene content map)
+  bool loop = 2;                                            // whether the clip repeats once it reaches the end
+  float speed = 3;                                          // playback speed multiplier (1.0 = clip's native rate)
+  bool idle = 4;                                            // true: a triggerSceneEmote may take over; false: emotes are suppressed while this animation plays
+  optional float transition_seconds = 5;                    // cross-fade duration when `src` changes; defaults to 0.2 when unset. Not applied to loop/speed/idle changes.
+  optional float playback_time = 6;                         // if set, the engine seeks to this position (in seconds) this frame. Clear on subsequent frames to allow normal playback. The scene can read `AvatarAnimationState.playback_time` first to decide.
 }
 
 // engine behaviour (uses only capsule shapecasts and GJK closest point for portability):

--- a/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/proto/decentraland/sdk/components/avatar_movement.proto
@@ -9,10 +9,12 @@ option (common.ecs_component_id) = 1501;
 
 message PBAvatarMovement {
   decentraland.common.Vector3 velocity = 1;
-  float orientation = 2;                                    // 0-360, we don't allow pitch/roll
+  float orientation = 2;                                    // 0-360, yaw only; this is the authoritative facing (other clients read it, and physics treats the avatar as upright). Lean is expressed separately via tilt_pitch/tilt_roll.
   optional decentraland.common.Vector3 ground_direction = 3;
   optional bool walk_success = 4;                           // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
   optional MovementAnimation animation = 5;                 // if set, the engine plays this animation instead of selecting one from velocity heuristics
+  optional float tilt_pitch = 6;                            // render-only forward/back lean in degrees, applied on top of `orientation` (rotation about the avatar's local X axis). Does not affect the physics capsule (stays upright) or the facing other clients read. Defaults to 0.
+  optional float tilt_roll = 7;                             // render-only sideways lean in degrees, applied on top of `orientation` (rotation about the avatar's local Z axis). Same constraints as tilt_pitch. Useful e.g. for glider banking. Defaults to 0.
 }
 
 // Describes the animation the movement scene wants the avatar to play.

--- a/proto/decentraland/sdk/components/avatar_movement_info.proto
+++ b/proto/decentraland/sdk/components/avatar_movement_info.proto
@@ -19,4 +19,18 @@ message PBAvatarMovementInfo {
   decentraland.sdk.components.PBInputModifier active_input_modifier = 7;
   optional decentraland.common.Vector3 walk_target = 8;    // if set, the movement scene should walk the player to this scene-relative position
   optional float walk_threshold = 9;                        // stop distance for walk_target; considered reached when within this distance
+  optional AvatarAnimationState active_animation_state = 10; // current state of a scene-driven movement animation. Absent when the engine is using its velocity-based fallback. `playback_time` freezes while a triggerSceneEmote is overriding the animation.
+}
+
+// Mirror of the scene-driven movement animation currently playing, reported by the engine.
+// Readable by any scene (not just the controller) so niche effects (e.g. dust cloud on landing) can react.
+// Active emotes are not represented here — scenes already have their own way to read them.
+message AvatarAnimationState {
+  string src = 1;                                           // same scene-relative path the controlling scene supplied
+  bool loop = 2;                                            // mirrors the request
+  float speed = 3;                                          // mirrors the request
+  bool idle = 4;                                            // mirrors the request
+  float playback_time = 5;                                  // seconds into the clip; wraps on loop; frozen while an emote override is playing
+  float duration = 6;                                       // total clip length in seconds
+  uint32 loop_count = 7;                                    // how many times the clip has completed since it started
 }


### PR DESCRIPTION
## Summary
- Adds `MovementAnimation` on `PBAvatarMovement` so the movement scene can drive avatar animation directly (`src`, `loop`, `speed`, `idle`, optional `transition_seconds`, optional `playback_time`). When absent the engine falls back to its built-in velocity-based selection.
- Adds `AvatarAnimationState` on `PBAvatarMovementInfo` so any scene can observe the currently-playing scene-driven clip (`src`, `loop`, `speed`, `idle`, `playback_time`, `duration`, `loop_count`). `playback_time` freezes while a `triggerSceneEmote` is overriding the clip.

Opened against `protocol-squad` so we can build a remote artifact to link `js-sdk-toolchain` against, and in turn link `movement-scene` so the downstream PRs are functional off this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)