### PR TITLE
feat(ui_input): add multi_line flag to PBUiInput

### DIFF
--- a/proto/decentraland/sdk/components/ui_input.proto
+++ b/proto/decentraland/sdk/components/ui_input.proto
@@ -17,4 +17,5 @@ message PBUiInput {
   optional common.Font font = 11; // default=0
   optional int32 font_size = 12; // default=10
   optional string value = 13;
+  optional bool multi_line = 14; // default=false; when true, the input accepts newlines and behaves as a textarea
 }


### PR DESCRIPTION
## Summary
- Adds `optional bool multi_line` (field 14) to `PBUiInput`. When true the input behaves as a multi-line textarea: plain Enter inserts a newline; Shift+Enter (or NumpadEnter) submits.
- Single-line behavior is unchanged when the flag is false/absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)