### PR TITLE
feat: add-hide-nametags

### DIFF
--- a/proto/decentraland/sdk/components/avatar_modifier_area.proto
+++ b/proto/decentraland/sdk/components/avatar_modifier_area.proto
@@ -29,4 +29,5 @@ message PBAvatarModifierArea {
 enum AvatarModifierType {
   AMT_HIDE_AVATARS = 0;      // avatars are invisible
   AMT_DISABLE_PASSPORTS = 1; // selecting (e.g. clicking) an avatar will not bring up their profile.
+  AMT_HIDE_NAMETAGS = 2;     // the name tag displayed above an avatar is hidden.
 }


### PR DESCRIPTION
in thi PR:
Adds a new `AMT_HIDE_NAMETAGS` value to the `AvatarModifierType` enum, 
allowing scenes to hide player name tags within a defined area via the 
existing `AvatarModifierArea` component.