### PR TITLE
feat: add IA_MODIFIER input action (value 14)

### DIFF
--- a/proto/decentraland/sdk/components/common/input_action.proto
+++ b/proto/decentraland/sdk/components/common/input_action.proto
@@ -17,6 +17,8 @@ enum InputAction {
   IA_ACTION_4 = 11;
   IA_ACTION_5 = 12;
   IA_ACTION_6 = 13;
+  // Modifier key (Shift on desktop)
+  IA_MODIFIER = 14;
 }
 
 // PointerEventType is a kind of interaction that can be detected.


### PR DESCRIPTION
## Summary

- Adds `IA_MODIFIER = 14` to the `InputAction` enum in the protobuf definition
- Maps to the Shift key on desktop — the runtime already recognizes this value
- Aligns the protocol definition with what the desktop client and [official docs](https://docs.decentraland.org/creator/scenes-sdk7/interactivity/button-events/click-events) already support

## Context

The Decentraland desktop client already handles `IA_MODIFIER` (value 14) as the Shift key input action, and it's documented in the official docs. However, the protocol definition and SDK type definitions don't include it, forcing developers to use `14 as any` as a workaround.

## Test plan

- [ ] Verify protobuf compiles successfully
- [ ] Verify generated code includes `IA_MODIFIER = 14`
- [ ] Confirm no breaking changes to existing enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)