### PR TITLE
feat: add screen_inset_area to PBUiCanvasInformation (cherry-pick of #399)

### DIFF
--- a/proto/decentraland/sdk/components/ui_canvas_information.proto
+++ b/proto/decentraland/sdk/components/ui_canvas_information.proto
@@ -26,5 +26,5 @@ message PBUiCanvasInformation {
   // platform UI (for example: the notch, status bar, home indicator, or rounded
   // corners on mobile). scenes should avoid placing critical UI within these
   // insets to ensure it is not occluded. on desktop this is typically (0, 0, 0, 0).
-  decentraland.common.BorderRect screen_inset_area = 5;
+  optional decentraland.common.BorderRect screen_inset_area = 5;
 }

--- a/proto/decentraland/sdk/components/ui_canvas_information.proto
+++ b/proto/decentraland/sdk/components/ui_canvas_information.proto
@@ -21,4 +21,10 @@ message PBUiCanvasInformation {
   // chat UI hidden and with no minimap could have a rect that covers the whole screen.
   // on the contrary, if the chat UI is shown, the rect would be smaller.
   decentraland.common.BorderRect interactable_area = 4;
+  // informs the sdk about the screen inset area (safe margins). these are the
+  // insets from each edge of the screen that are reserved by the device or
+  // platform UI (for example: the notch, status bar, home indicator, or rounded
+  // corners on mobile). scenes should avoid placing critical UI within these
+  // insets to ensure it is not occluded. on desktop this is typically (0, 0, 0, 0).
+  decentraland.common.BorderRect screen_inset_area = 5;
 }


### PR DESCRIPTION
Cherry-pick of #399 onto \`protocol-squad\`.

## Summary
- Adds \`screen_inset_area\` (field 5, \`decentraland.common.BorderRect\`) to \`PBUiCanvasInformation\` so scenes can read the device safe-area insets (notch, status bar, home indicator, rounded corners, etc.).
- Mainly useful on mobile to keep critical UI out of the unsafe regions; on desktop the value is typically \`(0, 0, 0, 0)\`.
- Reuses \`BorderRect\` for parity with the existing \`interactable_area\` field — same \`top/left/right/bottom\` semantics, no new message type needed.

## Test plan
- [x] \`make buf-lint\` passes in CI
- [x] \`make buf-breaking\` passes (additive field, backwards-compatible)
- [x] Land alongside or after #399 on \`main\`

Tracking the experimental implementation in js-sdk-toolchain at decentraland/js-sdk-toolchain#1386.