### PR TITLE
feat(ui_input): add clear_on_submit flag to PBUiInput

### DIFF
--- a/proto/decentraland/sdk/components/ui_input.proto
+++ b/proto/decentraland/sdk/components/ui_input.proto
@@ -18,4 +18,5 @@ message PBUiInput {
   optional int32 font_size = 12; // default=10
   optional string value = 13;
   optional bool multi_line = 14; // default=false; when true, the input accepts newlines and behaves as a textarea
+  optional bool clear_on_submit = 15; // default=true; when false, the input value is preserved after pressing Enter
 }


### PR DESCRIPTION
## Summary

Adds `clear_on_submit` (optional bool, default `true`) to `PBUiInput`. When `false`, the input value is preserved after pressing Enter instead of being cleared.

Scene creators currently have no control over this behavior — they have to implement workarounds (e.g., chat-style inputs where the text should remain after submit).

Refs: decentraland/bevy-explorer#773