### PR TITLE
chore: sync main into protocol-squad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .DS_Store
 out-*
 proto/google
+.idea

--- a/proto/decentraland/kernel/apis/comms_api.proto
+++ b/proto/decentraland/kernel/apis/comms_api.proto
@@ -20,6 +20,35 @@ message VideoTracksActiveStreamsData {
     VideoTrackSourceType source_type = 3;
 }
 
+message SubscribeToTopicRequest {
+  string topic = 1;
+}
+
+message SubscribeToTopicResponse {}
+
+message PublishDataRequest {
+  string topic = 1;
+  string data = 2;
+}
+
+message PublishDataResponse {}
+
+message ConsumeMessagesRequest {
+  string topic = 1;
+}
+
+message ConsumeMessages {
+  string sender = 1;
+  string data = 2;
+}
+
+message ConsumeMessagesResponse {
+  repeated ConsumeMessages messages = 1;
+}
+
 service CommsApiService {
   rpc GetActiveVideoStreams(VideoTracksActiveStreamsRequest) returns (VideoTracksActiveStreamsResponse) {}
+  rpc SubscribeToTopic(SubscribeToTopicRequest) returns (SubscribeToTopicResponse) {}
+  rpc PublishData(PublishDataRequest) returns (PublishDataResponse) {}
+  rpc ConsumeMessages(ConsumeMessagesRequest) returns (ConsumeMessagesResponse) {}
 }

--- a/proto/decentraland/kernel/apis/comms_api.proto
+++ b/proto/decentraland/kernel/apis/comms_api.proto
@@ -26,6 +26,12 @@ message SubscribeToTopicRequest {
 
 message SubscribeToTopicResponse {}
 
+message UnsubscribeFromTopicRequest {
+  string topic = 1;
+}
+
+message UnsubscribeFromTopicResponse {}
+
 message PublishDataRequest {
   string topic = 1;
   string data = 2;
@@ -49,6 +55,7 @@ message ConsumeMessagesResponse {
 service CommsApiService {
   rpc GetActiveVideoStreams(VideoTracksActiveStreamsRequest) returns (VideoTracksActiveStreamsResponse) {}
   rpc SubscribeToTopic(SubscribeToTopicRequest) returns (SubscribeToTopicResponse) {}
+  rpc UnsubscribeFromTopic(UnsubscribeFromTopicRequest) returns (UnsubscribeFromTopicResponse) {}
   rpc PublishData(PublishDataRequest) returns (PublishDataResponse) {}
   rpc ConsumeMessages(ConsumeMessagesRequest) returns (ConsumeMessagesResponse) {}
 }

--- a/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -18,6 +18,9 @@ message Packet {
     PlayerEmote player_emote = 9;
     SceneEmote scene_emote = 10;
     MovementCompressed movement_compressed = 12;
+    LookAtPosition look_at_position = 13;
+    Reaction reaction = 14;
+    ChatReaction chat_reaction = 15;
   }
   uint32 protocol_version = 11;
 }
@@ -137,4 +140,26 @@ message Voice {
   enum VoiceCodec {
     VC_OPUS = 0;
   }
+}
+
+// Message sent to force an avatar to look at a position
+message LookAtPosition {
+  float timestamp = 1;
+  // world position
+  float position_x = 2;
+  float position_y = 3;
+  float position_z = 4;
+  string target_avatar_wallet_address = 5;
+}
+
+message Reaction {
+  int32 emoji_index = 1;
+  float timestamp = 2;
+  int32 count = 3;
+}
+
+message ChatReaction {
+  int32 emoji_index = 1;
+  string message_id = 2;
+  string address = 3;
 }

--- a/proto/decentraland/sdk/components/audio_analysis.proto
+++ b/proto/decentraland/sdk/components/audio_analysis.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1212;
+
+enum PBAudioAnalysisMode {
+    MODE_RAW = 0;
+    MODE_LOGARITHMIC = 1;
+}
+
+message PBAudioAnalysis {
+
+    // Parameters section
+    PBAudioAnalysisMode mode = 1;
+
+    // Used only when mode == MODE_LOGARITHMIC
+    optional float amplitude_gain = 100;
+    optional float bands_gain = 101;
+    // End when mode == MODE_LOGARITHMIC
+
+    // End Parameters section
+
+    // Result section
+    float amplitude = 200;
+
+    // Protobuf doesn't support fixed arrays -> 8 band fields
+    float band_0 = 201;
+    float band_1 = 202;
+    float band_2 = 203;
+    float band_3 = 204;
+    float band_4 = 205;
+    float band_5 = 206;
+    float band_6 = 207;
+    float band_7 = 208;
+
+    // End Result section
+
+    // Future fields
+    // float spectral_centroid = 13;
+    // float spectral_flux = 14;
+    // bool onset = 15;
+    // float bpm = 16;
+}

--- a/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
+++ b/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
@@ -1,0 +1,18 @@
+﻿syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1211;
+
+// The PBAvatarLocomotionSettings component allows scenes to modify locomotion settings defining things such
+// as the avatar movement speed, jump height etc.
+message PBAvatarLocomotionSettings {
+  optional float walk_speed = 1;            // Maximum speed when walking (in meters per second)
+  optional float jog_speed = 2;             // Maximum speed when jogging (in meters per second)
+  optional float run_speed = 3;             // Maximum speed when running (in meters per second)
+  optional float jump_height = 4;           // Height of a regular jump (in meters)
+  optional float run_jump_height = 5;       // Height of a jump while running (in meters)
+  optional float hard_landing_cooldown = 6; // Cooldown time after a hard landing before the avatar can move again (in seconds)
+}

--- a/proto/decentraland/sdk/components/common/input_action.proto
+++ b/proto/decentraland/sdk/components/common/input_action.proto
@@ -17,6 +17,8 @@ enum InputAction {
   IA_ACTION_4 = 11;
   IA_ACTION_5 = 12;
   IA_ACTION_6 = 13;
+  // Modifier key (Shift on desktop)
+  IA_MODIFIER = 14;
 }
 
 // PointerEventType is a kind of interaction that can be detected.

--- a/proto/decentraland/sdk/components/particle_system.proto
+++ b/proto/decentraland/sdk/components/particle_system.proto
@@ -65,7 +65,7 @@ message PBParticleSystem {
   optional PlaybackState playback_state = 22; // default = PS_PLAYING
 
   // --- Emission Bursts ---
-  repeated Burst bursts = 29;
+  optional BurstConfiguration bursts = 29;
 
   // ---- Nested types ----
 
@@ -102,6 +102,10 @@ message PBParticleSystem {
   }
 
   // Emission burst configuration.
+  message BurstConfiguration {
+    repeated Burst values = 1;
+  }
+  
   message Burst {
     float time = 1;                // Seconds from start of cycle.
     uint32 count = 2;             // Particles to emit.


### PR DESCRIPTION
## Summary
- Merge latest `main` into `protocol-squad` to pick up 7 commits.
- Resolves conflict in `proto/decentraland/sdk/components/common/input_action.proto` — both branches added `IA_MODIFIER = 14`; kept main's version with the descriptive comment.

## Commits from main
- feat: locomotion settings (#398)
- feat: add IA_MODIFIER input action (value 14) (#396)
- feat: audio analysis sync to main (#338)
- feat: Add unsubscribeFromTopic method (#393)
- feat: add topic pub/sub RPCs to CommsApiService (#390)
- chore: update particle system bursts property (#386)
- feat: add LookAtPosition, Reaction and ChatReaction comms messages (#384)

## Test plan
- [ ] Verify generated proto bindings still compile
- [ ] Confirm `IA_MODIFIER` enum value is preserved with main's comment
- [ ] Check that no protocol-squad-specific commits were dropped