### PR TITLE
feat: add AMT_HIDE_NAMETAGS to AvatarModifierType

### DIFF
--- a/proto/decentraland/sdk/components/avatar_modifier_area.proto
+++ b/proto/decentraland/sdk/components/avatar_modifier_area.proto
@@ -31,6 +31,7 @@ message PBAvatarModifierArea {
 enum AvatarModifierType {
   AMT_HIDE_AVATARS = 0;      // avatars are invisible
   AMT_DISABLE_PASSPORTS = 1; // selecting (e.g. clicking) an avatar will not bring up their profile.
+  AMT_HIDE_NAMETAGS = 2;     // the name tag displayed above an avatar is hidden.
 }
 
 message AvatarMovementSettings {


### PR DESCRIPTION
## Summary

Adds a new `AMT_HIDE_NAMETAGS` value (= 2) to the `AvatarModifierType` enum so scenes can hide player name tags within an `AvatarModifierArea` region.

Targets `protocol-squad` so CI publishes a branch build of `@dcl/protocol` that the godot-explorer PR can consume. Mirror of #395 / #401 by @Gaffomdz, retargeted to `protocol-squad` to trigger the runners.

Companion PR: decentraland/godot-explorer#2079

## What could break

- New enum value only — purely additive, no behavior change for existing scenes or SDK consumers.

## How to test

- [ ] Wait for the CDN branch build to publish a `@dcl/protocol` `.tgz`
- [ ] Update `PROTOCOL_FIXED_VERSION_URL` in decentraland/godot-explorer#2079 to that `.tgz`
- [ ] Verify the godot client receives `AMT_HIDE_NAMETAGS = 2` and hides nametags in the area