### PR TITLE
feat: add AMT_HIDE_NAMETAGS modifier

### DIFF
--- a/proto/decentraland/sdk/components/avatar_modifier_area.proto
+++ b/proto/decentraland/sdk/components/avatar_modifier_area.proto
@@ -29,4 +29,5 @@ message PBAvatarModifierArea {
 enum AvatarModifierType {
   AMT_HIDE_AVATARS = 0;      // avatars are invisible
   AMT_DISABLE_PASSPORTS = 1; // selecting (e.g. clicking) an avatar will not bring up their profile.
+  AMT_HIDE_NAMETAGS = 2;     // the name tag displayed above an avatar is hidden.
 }


### PR DESCRIPTION
Adds AMT_HIDE_NAMETAGS = 2 to AvatarModifierType. Same change as #401 but targeting experimental so the generated tarball is compatible with unity-explorer's protocol baseline.