### PR TITLE
feat: add scrollable UI transform and UiScrollResult

### DIFF
--- a/proto/decentraland/sdk/components/ui_scroll_result.proto
+++ b/proto/decentraland/sdk/components/ui_scroll_result.proto
@@ -5,7 +5,7 @@ package decentraland.sdk.components;
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/vectors.proto";
 
-option (common.ecs_component_id) = 1100;
+option (common.ecs_component_id) = 1202;
 
 message PBUiScrollResult {
   decentraland.common.Vector2 value = 1;

--- a/proto/decentraland/sdk/components/ui_scroll_result.proto
+++ b/proto/decentraland/sdk/components/ui_scroll_result.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+import "decentraland/common/vectors.proto";
+
+option (common.ecs_component_id) = 1100;
+
+message PBUiScrollResult {
+  decentraland.common.Vector2 value = 1;
+}

--- a/proto/decentraland/sdk/components/ui_transform.proto
+++ b/proto/decentraland/sdk/components/ui_transform.proto
@@ -4,6 +4,7 @@ package decentraland.sdk.components;
 
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/colors.proto";
+import "decentraland/common/vectors.proto";
 
 option (common.ecs_component_id) = 1050;
 
@@ -78,6 +79,20 @@ enum YGEdge {
 enum PointerFilterMode {
   PFM_NONE = 0;
   PFM_BLOCK = 1;
+}
+
+enum ShowScrollBar {
+  SSB_BOTH = 0;
+  SSB_ONLY_VERTICAL = 1;
+  SSB_ONLY_HORIZONTAL = 2;
+  SSB_HIDDEN = 3;
+}
+
+message ScrollPositionValue {
+  oneof value {
+    decentraland.common.Vector2 position = 1;
+    string reference = 2;
+  }
 }
 
 message PBUiTransform {
@@ -174,5 +189,10 @@ message PBUiTransform {
   optional decentraland.common.Color4 border_right_color = 72;
 
   optional float opacity = 73; // default: 1
+
+  optional string element_id = 74; // reference for scroll_position. default empty
+  optional ScrollPositionValue scroll_position = 75; // default position=(0,0)
+  optional ShowScrollBar scroll_visible = 76; // default ShowScrollBar.SSB_BOTH
+
   optional int32 z_index = 77; // default: 0 — controls render stacking order. Higher values appear in front of lower values.
 }

--- a/proto/decentraland/sdk/components/ui_transform.proto
+++ b/proto/decentraland/sdk/components/ui_transform.proto
@@ -190,9 +190,21 @@ message PBUiTransform {
 
   optional float opacity = 73; // default: 1
 
-  optional string element_id = 74; // reference for scroll_position. default empty
-  optional ScrollPositionValue scroll_position = 75; // default position=(0,0)
-  optional ShowScrollBar scroll_visible = 76; // default ShowScrollBar.SSB_BOTH
+  // Unique name for this UI element (HTML-`id`-like). Registered in a
+  // named-element table so other components/RPCs can refer to it: today
+  // consumed by ScrollPositionValue.reference (scroll a named child into view)
+  // and the UI focus RPC. default empty
+  optional string element_id = 74;
+
+  // Scroll offset for this node's scroll viewport (only meaningful when
+  // overflow = YGO_SCROLL). Either a literal Vector2 position, or a string
+  // referencing another element's element_id to scroll into view.
+  // default position=(0,0)
+  optional ScrollPositionValue scroll_position = 75;
+
+  // Which scroll bars to render when this node is scrollable.
+  // default ShowScrollBar.SSB_BOTH
+  optional ShowScrollBar scroll_visible = 76;
 
   optional int32 z_index = 77; // default: 0 — controls render stacking order. Higher values appear in front of lower values.
 }


### PR DESCRIPTION
## Summary

Proposes adding scrollable UI containers and a programmatic way to observe / control their scroll state. Verified against the reference renderer in [`bevy-explorer`](https://github.com/decentraland/bevy-explorer) (`crates/scene_runner/src/update_world/scene_ui/mod.rs`, `crates/ui_core/src/scrollable.rs`), which already wires these fields end-to-end.

## What this adds

### `PBUiScrollResult` — new component (`ecs_component_id = 1202`)

Renderer → scene. The renderer writes the viewport's current scroll offset back to the scene whenever the user scrolls (wheel, drag, or programmatic move), letting scene logic react to scroll state.

```proto
message PBUiScrollResult {
  decentraland.common.Vector2 value = 1; // current scroll offset (h, v)
}
```

### `ui_transform.proto` additions

**`ShowScrollBar` enum** — which scroll bars are visible on a scrollable node:
- `SSB_BOTH` (default) — horizontal + vertical
- `SSB_ONLY_VERTICAL`
- `SSB_ONLY_HORIZONTAL`
- `SSB_HIDDEN` — no bars (content still scrollable via wheel/drag)

**`ScrollPositionValue` message** — `oneof`:
- `position` (`Vector2`) — literal scroll offset
- `reference` (`string`) — `element_id` of a descendant; the renderer scrolls the viewport so that element is visible

**Three new optional fields on `PBUiTransform`:**

| Field | # | Purpose |
|---|---|---|
| `element_id` | 74 | Unique name for **this** UI element (HTML-`id`-like). Registered in a named-element table so other components/RPCs can refer to it by name. Today consumed by `ScrollPositionValue.reference` and the UI focus RPC. Default: empty. |
| `scroll_position` | 75 | Scroll offset of this node's scroll viewport. Only meaningful when `overflow = YGO_SCROLL`. Default: `position=(0,0)`. |
| `scroll_visible` | 76 | Which scroll bars to render. Default: `SSB_BOTH`. |

## Proposed usage

### 1. Make a node scrollable

```ts
UiTransform.create(entity, {
  width: 300, height: 200,
  overflow: YGOverflow.YGO_SCROLL,     // required for scroll to engage
  scrollVisible: ShowScrollBar.SSB_ONLY_VERTICAL,
})
```

### 2. Set scroll position imperatively

```ts
UiTransform.createOrReplace(entity, {
  overflow: YGOverflow.YGO_SCROLL,
  scrollPosition: { value: { $case: 'position', position: { x: 0, y: 250 } } },
})
```

### 3. Scroll a named child into view

```ts
UiTransform.create(childEntity, { elementId: 'section-3', parent })

UiTransform.createOrReplace(parent, {
  overflow: YGOverflow.YGO_SCROLL,
  scrollPosition: { value: { $case: 'reference', reference: 'section-3' } },
})
```

### 4. React to user scrolling

```ts
const result = UiScrollResult.getOrNull(entity)
if (result?.value) {
  // result.value is the current { x, y } scroll offset
}
```

## Test plan

- [x] `make buf-lint` passes
- [x] `make buf-build` passes
- [ ] Confirm downstream SDK codegen picks up the new symbols
- [ ] Renderer (bevy-explorer / Unity) tested against a scene exercising literal scroll, reference scroll, and `PBUiScrollResult` read-back