### PR TITLE
chore: align PBUiScrollResult ecs_component_id with main

### DIFF
--- a/proto/decentraland/sdk/components/ui_scroll_result.proto
+++ b/proto/decentraland/sdk/components/ui_scroll_result.proto
@@ -5,7 +5,7 @@ package decentraland.sdk.components;
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/vectors.proto";
 
-option (common.ecs_component_id) = 1202;
+option (common.ecs_component_id) = 1100;
 
 message PBUiScrollResult {
   decentraland.common.Vector2 value = 1;


### PR DESCRIPTION
## Summary

Aligns `PBUiScrollResult` on `protocol-squad` (`1202`) with the value being proposed for `main` in #412 (`1100`), so the scroll-result component lands on `main` with the same ID it uses here — no divergence when squad next merges main.

## Test plan

- [x] `make buf-lint` passes
- [x] `make buf-build` passes
- [ ] Merge after / together with #412 so both branches end up on `1100`