### PR TITLE
feat: collision layer for main player (main)

### DIFF
--- a/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/proto/decentraland/sdk/components/mesh_collider.proto
@@ -45,8 +45,8 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_PLAYER = 4;         // layer corresponding to any player avatar
-  CL_RESERVED2 = 8;
+  CL_PLAYER = 4;         // layer corresponding to any player avatar (main + remote)
+  CL_MAIN_PLAYER = 8;    // layer corresponding to the local (main) player avatar
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;
   CL_RESERVED5 = 64;


### PR DESCRIPTION
Updated reserved Collider Layer to be used for MAIN PLAYER detection only.

## Related PRs
- https://github.com/decentraland/unity-explorer/pull/8865
- https://github.com/decentraland/js-sdk-toolchain/pull/1414
- https://github.com/decentraland/docs/pull/104
- https://github.com/decentraland/sdk7-test-scenes/pull/71