### PR TITLE
feat: add MobileInputControls and UiInputBinding components

### DIFF
--- a/proto/decentraland/sdk/components/mobile_input_controls.proto
+++ b/proto/decentraland/sdk/components/mobile_input_controls.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1218;
+
+// The MobileInputControls component lets a scene hide the native on-screen mobile
+// controls (the virtual joystick and/or the action button cluster) so creators can
+// render their own touch UI and bind it with the UiInputBinding component.
+//
+// It must be set on the PlayerEntity. It is a no-op on platforms without native
+// on-screen controls (e.g. desktop).
+message PBMobileInputControls {
+    bool hide_joystick = 1; // hide the native virtual joystick
+    bool hide_gamepad = 2;  // hide the native action button cluster (jump / primary / etc.)
+}

--- a/proto/decentraland/sdk/components/ui_input_binding.proto
+++ b/proto/decentraland/sdk/components/ui_input_binding.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+import "decentraland/sdk/components/common/id.proto";
+import "decentraland/sdk/components/common/input_action.proto";
+option (common.ecs_component_id) = 1219;
+
+// The UiInputBinding component binds a UI entity to one or more InputActions. While the
+// element is pressed (touch or pointer) the listed actions are held down, driving both
+// the local player input and scene InputAction listeners, just like the native on-screen
+// buttons. It is typically combined with MobileInputControls to replace the native
+// controls with a custom touch UI.
+message PBUiInputBinding {
+    repeated common.InputAction actions = 1; // the input actions fired while this element is pressed
+}


### PR DESCRIPTION
## What

  Adds two new SDK components that let scenes build custom on-screen mobile controls:

  - **`PBMobileInputControls`** (component id `1218`) — set on the `PlayerEntity`, hides the native on-screen mobile controls so creators can render their own touch UI. No-op on platforms without native
  on-screen controls (e.g. desktop).
    - `bool hide_joystick = 1` — hide the native virtual joystick
    - `bool hide_gamepad = 2` — hide the native action button cluster (jump / primary / etc.)

  - **`PBUiInputBinding`** (component id `1219`) — set on a UI entity, binds it to one or more `InputAction`s. While the element is pressed (touch or pointer) the listed actions are held down, driving both the
  local player input and scene `InputAction` listeners — just like the native on-screen buttons. Typically combined with `MobileInputControls` to replace the native controls with a custom touch UI.
    - `repeated common.InputAction actions = 1`
  
  ## Why

  Content creators currently cannot replace the native mobile joystick/gamepad with their own UI, nor make a scene UI element trigger a player input action. This is the "destroy TouchGui + BindAction" workflow
  familiar from other engines. Together these two components unblock fully custom touch controls.