### PR TITLE
feat: add AMT_HIDE_NAMETAGS modifier

### DIFF
--- a/proto/decentraland/sdk/components/avatar_modifier_area.proto
+++ b/proto/decentraland/sdk/components/avatar_modifier_area.proto
@@ -29,4 +29,5 @@ message PBAvatarModifierArea {
 enum AvatarModifierType {
   AMT_HIDE_AVATARS = 0;      // avatars are invisible
   AMT_DISABLE_PASSPORTS = 1; // selecting (e.g. clicking) an avatar will not bring up their profile.
+  AMT_HIDE_NAMETAGS = 2;     // the name tag displayed above an avatar is hidden.
 }


### PR DESCRIPTION
## Summary
Adds `AMT_HIDE_NAMETAGS = 2` to `AvatarModifierType`. This ports the same change as #411 (merged to `experimental`) / #401 into `main`.

## What could break
None expected — purely additive enum value. Existing values are unchanged, so wire compatibility is preserved.

## How to test
Regenerate the protocol bindings and confirm `AMT_HIDE_NAMETAGS` is available in the generated `AvatarModifierType` enum.