### PR TITLE
feat: power-law quantized float option; apply to Pulse velocity deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ message PositionDelta {
 | Annotation | Target type | Parameters | Effect |
 |---|---|---|---|
 | `[(decentraland.common.quantized)]` | `uint32` | `min`, `max`, `bits` | Linear quantizer over `[min, max]`. Plugin emits a cached `float {Name}Quantized` accessor (`Quantize.Encode`/`Decode`) |
-| `[(decentraland.common.quantized_power)]` | `uint32` | `max`, `pow`, `bits` | Power-law quantizer over `[-max, max]`: sign bit + `(bits-1)`-bit linear unorm magnitude, decoded as `sign·max·u^pow`. Exact zero; `pow>1` gives fine resolution near zero, coarse near `±max`. Same `float {Name}Quantized` accessor (`Quantize.EncodePower`/`DecodePower`) |
+| `[(decentraland.common.quantized_power)]` | `uint32` | `max`, `pow`, `bits` | Power-law quantizer over `[-max, max]`: `(bits-1)`-bit linear unorm magnitude (high bits) + sign (LSB), decoded as `sign·max·u^pow`. Exact zero; `pow>1` gives fine resolution near zero, coarse near `±max`; sign in the LSB keeps small magnitudes one varint byte. Same `float {Name}Quantized` accessor (`Quantize.EncodePower`/`DecodePower`) |
 | `[(decentraland.common.bit_packed)]` | `uint32` | `bits` | Documents the value range; protobuf handles varint compaction automatically |
 
 ### Wire cost at worst-case (all bits set)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ message PositionDelta {
 
 | Annotation | Target type | Parameters | Effect |
 |---|---|---|---|
-| `[(decentraland.common.quantized)]` | `uint32` | `min`, `max`, `bits` | Plugin emits a cached `float {Name}Quantized` accessor |
+| `[(decentraland.common.quantized)]` | `uint32` | `min`, `max`, `bits` | Linear quantizer over `[min, max]`. Plugin emits a cached `float {Name}Quantized` accessor (`Quantize.Encode`/`Decode`) |
+| `[(decentraland.common.quantized_power)]` | `uint32` | `max`, `pow`, `bits` | Power-law quantizer over `[-max, max]`: sign bit + `(bits-1)`-bit linear unorm magnitude, decoded as `sign·max·u^pow`. Exact zero; `pow>1` gives fine resolution near zero, coarse near `±max`. Same `float {Name}Quantized` accessor (`Quantize.EncodePower`/`DecodePower`) |
 | `[(decentraland.common.bit_packed)]` | `uint32` | `bits` | Documents the value range; protobuf handles varint compaction automatically |
 
 ### Wire cost at worst-case (all bits set)

--- a/proto/decentraland/common/options.proto
+++ b/proto/decentraland/common/options.proto
@@ -14,6 +14,19 @@ message QuantizedFloatOptions {
   uint32 bits = 3;
 }
 
+// Options for quantizing a signed float with a power-law curve, stored as a uint32 field.
+// The value is split into a sign bit plus an (bits-1)-bit linear unorm magnitude `u in [0, 1]`,
+// and reconstructed as `value = sign * max * u^pow`. Because `u = 0` maps to exactly `0`, zero is
+// representable (unlike the linear quantizer, whose codes straddle zero), and `pow > 1` concentrates
+// resolution near zero — useful for fields like velocity that need fine detail at low magnitudes and
+// only coarse detail near the extremes. The range is symmetric ([-max, max]); there is no `min`.
+// The generator emits a float {Name}Quantized accessor, same as the linear option.
+message QuantizedPowerFloatOptions {
+  float  max  = 1;
+  float  pow  = 2;
+  uint32 bits = 3;
+}
+
 // Options for bit-packing an integer field into fewer than 32 bits.
 message BitPackedOptions {
   uint32 bits = 1;
@@ -27,4 +40,9 @@ extend google.protobuf.FieldOptions {
   // Apply to uint32 fields to pack into fewer bits.
   // Example: uint32 entity_id = 4 [(decentraland.common.bit_packed) = { bits: 20 }];
   BitPackedOptions      bit_packed = 50002;
+
+  // Apply to uint32 fields to enable power-law quantized float encoding (sign + magnitude curve).
+  // A field carries either `quantized` or `quantized_power`, not both.
+  // Example: uint32 velocity_x = 9 [(decentraland.common.quantized_power) = { max: 50.0, pow: 2.0, bits: 8 }];
+  QuantizedPowerFloatOptions quantized_power = 50003;
 }

--- a/proto/decentraland/common/options.proto
+++ b/proto/decentraland/common/options.proto
@@ -15,11 +15,14 @@ message QuantizedFloatOptions {
 }
 
 // Options for quantizing a signed float with a power-law curve, stored as a uint32 field.
-// The value is split into a sign bit plus an (bits-1)-bit linear unorm magnitude `u in [0, 1]`,
+// The value is split into an (bits-1)-bit linear unorm magnitude `u in [0, 1]` plus a sign,
 // and reconstructed as `value = sign * max * u^pow`. Because `u = 0` maps to exactly `0`, zero is
 // representable (unlike the linear quantizer, whose codes straddle zero), and `pow > 1` concentrates
 // resolution near zero — useful for fields like velocity that need fine detail at low magnitudes and
 // only coarse detail near the extremes. The range is symmetric ([-max, max]); there is no `min`.
+// The encoded layout puts the magnitude in the high bits and the sign in the LSB
+// (`(magnitude << 1) | sign`), so the varint cost tracks magnitude, not direction: a small `|value|`
+// of either sign stays in one varint byte. Zero canonicalizes to `0`, so proto3 omits a stopped field.
 // The generator emits a float {Name}Quantized accessor, same as the linear option.
 message QuantizedPowerFloatOptions {
   float  max  = 1;

--- a/proto/decentraland/common/quantization_example.proto
+++ b/proto/decentraland/common/quantization_example.proto
@@ -15,6 +15,11 @@ import "decentraland/common/options.proto";
 //       → protobuf encodes the uint32 as a varint: values ≤ 2^14-1 cost 2 bytes,
 //         values ≤ 2^21-1 cost 3 bytes; the generated partial class adds a
 //         float {Name}Quantized accessor that encodes/decodes transparently.
+//   [(decentraland.common.quantized_power) = { max: F, pow: F, bits: N }]
+//       → stores a signed float over [-max, max] as a sign bit + (N-1)-bit linear
+//         unorm magnitude, reconstructed as sign·max·u^pow. Zero is exact, and
+//         pow>1 buys fine resolution near zero at the cost of coarse near ±max.
+//         Same generated float {Name}Quantized accessor as the linear option.
 //   [(decentraland.common.bit_packed) = { bits: N }]
 //       → documents that this uint32 uses at most N bits; protobuf encodes it
 //         as a varint (same savings, no generated accessor needed).
@@ -80,6 +85,29 @@ message PlayerInput {
 
   // Rolling input sequence number used by the server for reconciliation.
   uint32 sequence = 5 [(decentraland.common.bit_packed) = { bits: 12 }];
+}
+
+// ---------------------------------------------------------------------------
+// VelocityState — per-axis velocity, demonstrating the power-law quantizer.
+//
+// Velocity needs an exact zero (a stopped avatar must read 0, not a quantization
+// residual, or it drifts) and fine resolution at locomotion speeds, but only
+// coarse resolution near the ±50 m/s extremes. The linear quantizer can give
+// none of these from 8 bits: its codes straddle zero (±0.196) and spend uniform
+// resolution on speeds that never occur. quantized_power solves all three.
+//
+//  Field  | Type   | Range      | pow | bits | Wire worst-case
+//  -------|--------|------------|-----|------|-----------------------
+//  vx     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
+//  vy     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
+//  vz     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
+//  ---------------------------------------------------------------------------
+//  Step: ≈ 0.003 m/s near zero, ≈ 0.78 m/s near ±50 (vs. 0.392 uniform linear)
+// ---------------------------------------------------------------------------
+message VelocityState {
+  uint32 vx = 1 [(decentraland.common.quantized_power) = { max: 50.0, pow: 2.0, bits: 8 }];
+  uint32 vy = 2 [(decentraland.common.quantized_power) = { max: 50.0, pow: 2.0, bits: 8 }];
+  uint32 vz = 3 [(decentraland.common.quantized_power) = { max: 50.0, pow: 2.0, bits: 8 }];
 }
 
 // Bitmask values for PlayerInput.buttons.

--- a/proto/decentraland/common/quantization_example.proto
+++ b/proto/decentraland/common/quantization_example.proto
@@ -16,10 +16,12 @@ import "decentraland/common/options.proto";
 //         values ≤ 2^21-1 cost 3 bytes; the generated partial class adds a
 //         float {Name}Quantized accessor that encodes/decodes transparently.
 //   [(decentraland.common.quantized_power) = { max: F, pow: F, bits: N }]
-//       → stores a signed float over [-max, max] as a sign bit + (N-1)-bit linear
-//         unorm magnitude, reconstructed as sign·max·u^pow. Zero is exact, and
-//         pow>1 buys fine resolution near zero at the cost of coarse near ±max.
-//         Same generated float {Name}Quantized accessor as the linear option.
+//       → stores a signed float over [-max, max] as an (N-1)-bit linear unorm
+//         magnitude (high bits) plus a sign (LSB), reconstructed as sign·max·u^pow.
+//         Zero is exact, and pow>1 buys fine resolution near zero at the cost of
+//         coarse near ±max. Putting the sign in the LSB keeps a small |value| of
+//         either direction in one varint byte. Same generated float {Name}Quantized
+//         accessor as the linear option.
 //   [(decentraland.common.bit_packed) = { bits: N }]
 //       → documents that this uint32 uses at most N bits; protobuf encodes it
 //         as a varint (same savings, no generated accessor needed).
@@ -98,11 +100,13 @@ message PlayerInput {
 //
 //  Field  | Type   | Range      | pow | bits | Wire worst-case
 //  -------|--------|------------|-----|------|-----------------------
-//  vx     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
-//  vy     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
-//  vz     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 2B = 3B
+//  vx     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 1–2B = 2–3B
+//  vy     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 1–2B = 2–3B
+//  vz     | uint32 | [-50, 50]  |  2  |  8   | tag 1B + varint 1–2B = 2–3B
 //  ---------------------------------------------------------------------------
 //  Step: ≈ 0.003 m/s near zero, ≈ 0.78 m/s near ±50 (vs. 0.392 uniform linear)
+//  Wire: sign in the LSB, so |v| ≲ 12.5 m/s (magnitude code ≤ 63) costs a single
+//        varint byte regardless of direction; only faster axes spill to 2 bytes.
 // ---------------------------------------------------------------------------
 message VelocityState {
   uint32 vx = 1 [(decentraland.common.quantized_power) = { max: 50.0, pow: 2.0, bits: 8 }];

--- a/proto/decentraland/pulse/pulse_server.proto
+++ b/proto/decentraland/pulse/pulse_server.proto
@@ -37,9 +37,13 @@ message PlayerStateDeltaTier0 {
   // Z position inside the parcel
   optional uint32 position_z = 8 [(decentraland.common.quantized) = { min:  0,  max:   16, bits: 8 }];
 
-  optional uint32 velocity_x = 9 [(decentraland.common.quantized) = { min:  -50,  max:   50, bits: 8 }];
-  optional uint32 velocity_y = 10 [(decentraland.common.quantized) = { min:  -50,  max:   50, bits: 8 }];
-  optional uint32 velocity_z = 11 [(decentraland.common.quantized) = { min:  -50,  max:   50, bits: 8 }];
+  // Power-law quantized: a sign bit + 7-bit magnitude curve over [-50, 50]. Zero is exactly
+  // representable (a stopped peer reports an exact 0 instead of the linear quantizer's ±0.196
+  // residual that drove foreign-avatar drift), and pow=2 concentrates resolution at the low speeds
+  // where avatars actually move, leaving only the visually-irrelevant extremes coarse.
+  optional uint32 velocity_x = 9 [(decentraland.common.quantized_power) = { max: 50, pow: 2, bits: 8 }];
+  optional uint32 velocity_y = 10 [(decentraland.common.quantized_power) = { max: 50, pow: 2, bits: 8 }];
+  optional uint32 velocity_z = 11 [(decentraland.common.quantized_power) = { max: 50, pow: 2, bits: 8 }];
 
   optional uint32 rotation_y = 12 [(decentraland.common.quantized) = { min:  0,  max:   360.0, bits: 7 }];
   optional uint32 movement_blend = 13 [(decentraland.common.quantized) = { min:  0,  max:   3, bits: 5 }];

--- a/protoc-gen-bitwise/generator_csharp.py
+++ b/protoc-gen-bitwise/generator_csharp.py
@@ -60,13 +60,13 @@ def _gen_message(msg_proto, indent: str = '    ') -> list[str] | None:
     """
     Generate a C# partial class for a proto message.
 
-    For each uint32 field with a [(quantized)] annotation, emits a cached float
-    property {FieldName}Quantized backed by the raw uint32 field.
+    For each uint32 field with a [(quantized)] or [(quantized_power)] annotation,
+    emits a cached float property {FieldName}Quantized backed by the raw uint32 field.
 
     Returns a list of lines (without trailing newline) or None if the message
     has no quantized uint32 fields.
     """
-    props: list[tuple[str, str, str, int, float]] = []  # (prop_name, mn, mx, bits, step)
+    props: list[tuple[str, str, str, str]] = []  # (prop_name, doc, get_expr, set_expr)
 
     for field in msg_proto.field:
         # Repeated/map fields are not supported
@@ -77,19 +77,32 @@ def _gen_message(msg_proto, indent: str = '    ') -> list[str] | None:
         if field.type != _FT.TYPE_UINT32:
             continue
 
-        quantized, _ = get_field_options(field.options)
-        if quantized is None:
+        quantized, _, quantized_power = get_field_options(field.options)
+        prop_name = _snake_to_pascal(field.name)
+
+        if quantized is not None:
+            mn = _format_float(quantized.min)
+            mx = _format_float(quantized.max)
+            bits = quantized.bits
+            step = (quantized.max - quantized.min) / ((1 << bits) - 1)
+            doc = f'Range [{mn}, {mx}], {bits} bits, step {_format_step(step)}.'
+            get_expr = f'Quantize.Decode({prop_name}, {mn}, {mx}, {bits})'
+            set_expr = f'Quantize.Encode(value, {mn}, {mx}, {bits})'
+        elif quantized_power is not None:
+            mx = _format_float(quantized_power.max)
+            pw = _format_float(quantized_power.pow)
+            bits = quantized_power.bits
+            # Power curve is non-uniform; the finest step sits next to zero (first magnitude code).
+            mag_steps = (1 << (bits - 1)) - 1
+            near_zero_step = quantized_power.max * (1.0 / mag_steps) ** quantized_power.pow
+            doc = (f'Range [-{mx}, {mx}], power {pw}, {bits} bits '
+                   f'(sign + {bits - 1}-bit magnitude), near-zero step {_format_step(near_zero_step)}.')
+            get_expr = f'Quantize.DecodePower({prop_name}, {mx}, {pw}, {bits})'
+            set_expr = f'Quantize.EncodePower(value, {mx}, {pw}, {bits})'
+        else:
             continue
 
-        step = (quantized.max - quantized.min) / ((1 << quantized.bits) - 1)
-
-        props.append((
-            _snake_to_pascal(field.name),
-            _format_float(quantized.min),
-            _format_float(quantized.max),
-            quantized.bits,
-            step,
-        ))
+        props.append((prop_name, doc, get_expr, set_expr))
 
     if not props:
         return None
@@ -100,15 +113,15 @@ def _gen_message(msg_proto, indent: str = '    ') -> list[str] | None:
     lines.append(f'public partial class {msg_proto.name}')
     lines.append('{')
 
-    for prop_name, mn, mx, bits, step in props:
+    for prop_name, doc, get_expr, set_expr in props:
         backing = '_' + prop_name[0].lower() + prop_name[1:]
         backings.append(backing)
         lines.append(f'{i}private float? {backing};')
-        lines.append(f'{i}/// <summary>Float accessor for <see cref="{prop_name}"/>. Range [{mn}, {mx}], {bits} bits, step {_format_step(step)}.</summary>')
+        lines.append(f'{i}/// <summary>Float accessor for <see cref="{prop_name}"/>. {doc}</summary>')
         lines.append(f'{i}public float {prop_name}Quantized')
         lines.append(f'{i}{{')
-        lines.append(f'{i}{i}get => {backing} ??= Quantize.Decode({prop_name}, {mn}, {mx}, {bits});')
-        lines.append(f'{i}{i}set {{ {backing} = value; {prop_name} = Quantize.Encode(value, {mn}, {mx}, {bits}); }}')
+        lines.append(f'{i}{i}get => {backing} ??= {get_expr};')
+        lines.append(f'{i}{i}set {{ {backing} = value; {prop_name} = {set_expr}; }}')
         lines.append(f'{i}}}')
         lines.append('')
 

--- a/protoc-gen-bitwise/options_pb2.py
+++ b/protoc-gen-bitwise/options_pb2.py
@@ -18,6 +18,7 @@ import struct
 # Extension field numbers as defined in options.proto
 QUANTIZED_FIELD_NUMBER = 50001
 BIT_PACKED_FIELD_NUMBER = 50002
+QUANTIZED_POWER_FIELD_NUMBER = 50003
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +96,38 @@ class QuantizedFloatOptions:
         return f'QuantizedFloatOptions(min={self.min}, max={self.max}, bits={self.bits})'
 
 
+class QuantizedPowerFloatOptions:
+    """Mirrors the QuantizedPowerFloatOptions proto message."""
+
+    __slots__ = ('max', 'pow', 'bits')
+
+    def __init__(self, max_val: float = 0.0, pow_val: float = 0.0, bits: int = 0):
+        self.max = max_val
+        self.pow = pow_val
+        self.bits = bits
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> 'QuantizedPowerFloatOptions':
+        obj = cls()
+        pos = 0
+        while pos < len(data):
+            tag, pos = _read_varint(data, pos)
+            field_num = tag >> 3
+            wire_type = tag & 0x7
+            if field_num == 1 and wire_type == 5:    # max  (float)
+                obj.max, pos = _read_float32(data, pos)
+            elif field_num == 2 and wire_type == 5:  # pow  (float)
+                obj.pow, pos = _read_float32(data, pos)
+            elif field_num == 3 and wire_type == 0:  # bits (uint32)
+                obj.bits, pos = _read_varint(data, pos)
+            else:
+                pos = _skip_field(data, pos, wire_type)
+        return obj
+
+    def __repr__(self):
+        return f'QuantizedPowerFloatOptions(max={self.max}, pow={self.pow}, bits={self.bits})'
+
+
 class BitPackedOptions:
     """Mirrors the BitPackedOptions proto message."""
 
@@ -130,25 +163,28 @@ def get_field_options(field_options_proto):
     Extract custom bitwise options from a FieldDescriptorProto.options object.
 
     Serialises the options message to bytes and walks the wire-format stream
-    looking for extension fields 50001 (quantized) and 50002 (bit_packed).
+    looking for extension fields 50001 (quantized), 50002 (bit_packed) and
+    50003 (quantized_power).
 
     Args:
         field_options_proto: google.protobuf.descriptor_pb2.FieldOptions instance
             (may be a default/empty instance when no options are set).
 
     Returns:
-        tuple[QuantizedFloatOptions | None, BitPackedOptions | None]
+        tuple[QuantizedFloatOptions | None, BitPackedOptions | None,
+              QuantizedPowerFloatOptions | None]
     """
     try:
         raw = field_options_proto.SerializeToString()
     except Exception:
-        return None, None
+        return None, None, None
 
     if not raw:
-        return None, None
+        return None, None, None
 
     quantized = None
     bit_packed = None
+    quantized_power = None
     pos = 0
 
     while pos < len(raw):
@@ -164,8 +200,10 @@ def get_field_options(field_options_proto):
                 quantized = QuantizedFloatOptions.from_bytes(value_bytes)
             elif field_num == BIT_PACKED_FIELD_NUMBER:
                 bit_packed = BitPackedOptions.from_bytes(value_bytes)
+            elif field_num == QUANTIZED_POWER_FIELD_NUMBER:
+                quantized_power = QuantizedPowerFloatOptions.from_bytes(value_bytes)
             # else: unknown length-delimited field — already consumed
         else:
             pos = _skip_field(raw, pos, wire_type)
 
-    return quantized, bit_packed
+    return quantized, bit_packed, quantized_power

--- a/protoc-gen-bitwise/runtime/cs/Quantize.cs
+++ b/protoc-gen-bitwise/runtime/cs/Quantize.cs
@@ -31,5 +31,34 @@ namespace Decentraland.Networking.Bitwise
             var steps = (1u << bits) - 1;
             return (float)encoded / steps * (max - min) + min;
         }
+
+        /// <summary>
+        ///     Encodes <paramref name="value" /> with a power-law curve into a sign bit plus an
+        ///     (<paramref name="bits" /> - 1)-bit linear unorm magnitude. The magnitude is
+        ///     <c>(|value| / max)^(1/pow)</c>, so the inverse <see cref="DecodePower" /> reconstructs
+        ///     <c>sign * max * u^pow</c>. Zero is representable exactly; <paramref name="pow" /> &gt; 1
+        ///     concentrates resolution near zero. Magnitudes outside [0, <paramref name="max" />] are
+        ///     clamped.
+        /// </summary>
+        public static uint EncodePower(float value, float max, float pow, int bits)
+        {
+            var magnitudeSteps = (1u << (bits - 1)) - 1;
+            var t = Math.Clamp(MathF.Abs(value) / max, 0f, 1f);
+            var u = MathF.Pow(t, 1f / pow);
+            var magnitude = (uint)MathF.Round(u * magnitudeSteps);
+            var sign = value < 0f ? 1u << (bits - 1) : 0u;
+            return sign | magnitude;
+        }
+
+        /// <summary>Decodes a power-law quantized <see cref="uint" /> back to a float (inverse of
+        /// <see cref="EncodePower" />).</summary>
+        public static float DecodePower(uint encoded, float max, float pow, int bits)
+        {
+            var signBit = 1u << (bits - 1);
+            var magnitudeSteps = signBit - 1;
+            var u = (float)(encoded & magnitudeSteps) / magnitudeSteps;
+            var magnitude = max * MathF.Pow(u, pow);
+            return (encoded & signBit) != 0 ? -magnitude : magnitude;
+        }
     }
 }

--- a/protoc-gen-bitwise/runtime/cs/Quantize.cs
+++ b/protoc-gen-bitwise/runtime/cs/Quantize.cs
@@ -33,12 +33,19 @@ namespace Decentraland.Networking.Bitwise
         }
 
         /// <summary>
-        ///     Encodes <paramref name="value" /> with a power-law curve into a sign bit plus an
-        ///     (<paramref name="bits" /> - 1)-bit linear unorm magnitude. The magnitude is
+        ///     Encodes <paramref name="value" /> with a power-law curve into an
+        ///     (<paramref name="bits" /> - 1)-bit linear unorm magnitude plus a sign bit. The magnitude is
         ///     <c>(|value| / max)^(1/pow)</c>, so the inverse <see cref="DecodePower" /> reconstructs
         ///     <c>sign * max * u^pow</c>. Zero is representable exactly; <paramref name="pow" /> &gt; 1
         ///     concentrates resolution near zero. Magnitudes outside [0, <paramref name="max" />] are
         ///     clamped.
+        ///     <para>
+        ///     The encoded layout puts the magnitude in the high bits and the sign in the LSB
+        ///     (<c>(magnitude &lt;&lt; 1) | sign</c>). This keeps the varint cost a function of
+        ///     magnitude rather than direction — a small <c>|value|</c> of either sign stays in a
+        ///     single varint byte. Zero canonicalizes to <c>0</c> (a zero magnitude never sets the
+        ///     sign bit), so proto3 still omits a stopped field entirely.
+        ///     </para>
         /// </summary>
         public static uint EncodePower(float value, float max, float pow, int bits)
         {
@@ -46,19 +53,18 @@ namespace Decentraland.Networking.Bitwise
             var t = Math.Clamp(MathF.Abs(value) / max, 0f, 1f);
             var u = MathF.Pow(t, 1f / pow);
             var magnitude = (uint)MathF.Round(u * magnitudeSteps);
-            var sign = value < 0f ? 1u << (bits - 1) : 0u;
-            return sign | magnitude;
+            var sign = value < 0f && magnitude != 0u ? 1u : 0u;
+            return (magnitude << 1) | sign;
         }
 
         /// <summary>Decodes a power-law quantized <see cref="uint" /> back to a float (inverse of
         /// <see cref="EncodePower" />).</summary>
         public static float DecodePower(uint encoded, float max, float pow, int bits)
         {
-            var signBit = 1u << (bits - 1);
-            var magnitudeSteps = signBit - 1;
-            var u = (float)(encoded & magnitudeSteps) / magnitudeSteps;
+            var magnitudeSteps = (1u << (bits - 1)) - 1;
+            var u = (float)(encoded >> 1) / magnitudeSteps;
             var magnitude = max * MathF.Pow(u, pow);
-            return (encoded & signBit) != 0 ? -magnitude : magnitude;
+            return (encoded & 1u) != 0 ? -magnitude : magnitude;
         }
     }
 }


### PR DESCRIPTION
## What

Adds a new field option `(decentraland.common.quantized_power)` for `uint32` fields and applies it to the Pulse `PlayerStateDeltaTier0` velocity deltas.

The existing linear `(decentraland.common.quantized)` option maps a float range `[min, max]` uniformly onto N bits. The new power option instead encodes:

- **1 sign bit** + **`(bits-1)`-bit linear unorm magnitude** `u ∈ [0,1]`
- decoded as `value = sign · max · u^pow`

Two properties matter for velocity:

1. **Zero is exactly representable** (`u = 0 → 0`). The linear quantizer can't hit an exact 0 over `[-50, 50]` in 8 bits — the nearest codes straddle zero with a `±0.196` residual, which drove a steady drift on *stopped* foreign avatars.
2. **`pow > 1` concentrates resolution near zero**, where avatars actually move, leaving the visually-irrelevant extremes coarse.

`velocity_x/y/z` switch from `quantized{min:-50, max:50, bits:8}` to `quantized_power{max:50, pow:2, bits:8}` — same 8 bits on the wire.

## Implemented end to end

- `proto/decentraland/common/options.proto` — `QuantizedPowerFloatOptions` message + extension (`quantized_power = 50003`)
- `protoc-gen-bitwise/options_pb2.py` — wire parser for the new option
- `protoc-gen-bitwise/runtime/cs/Quantize.cs` — `Quantize.EncodePower` / `DecodePower`
- `protoc-gen-bitwise/generator_csharp.py` — generator dispatch (linear vs power)
- `proto/decentraland/pulse/pulse_server.proto` — velocity 9/10/11 switched to `quantized_power`
- `README.md` + `proto/decentraland/common/quantization_example.proto` — docs / example

## Compatibility

This is a **breaking wire change** for `velocity_x/y/z`: the bit layout of those fields changes. Server (pulse) and Unity must regenerate and deploy in lockstep. Base branch `feat/pulse-prd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)