### PR TITLE
feat: add stream close reason to social service v2 subscription updates

### DIFF
--- a/proto/decentraland/social_service/v2/social_service_v2.proto
+++ b/proto/decentraland/social_service/v2/social_service_v2.proto
@@ -112,6 +112,34 @@ message UpsertFriendshipResponse {
   }
 }
 
+// Subscription stream lifecycle
+
+// Reason codes for a server-initiated closure of a subscription stream.
+enum SubscriptionStreamClosedReason {
+  // The server did not specify a finer-grained reason.
+  STREAM_CLOSED_UNKNOWN = 0;
+  // The server is shutting down or draining its connections.
+  STREAM_CLOSED_SERVER_SHUTTING_DOWN = 1;
+  // The connection already has an active subscription for this stream.
+  STREAM_CLOSED_DUPLICATE_SUBSCRIPTION = 2;
+  // The connection is no longer authorized to keep the stream open.
+  STREAM_CLOSED_UNAUTHORIZED = 3;
+  // The server cleaned up the subscription after detecting its state was stale.
+  STREAM_CLOSED_STALE_SUBSCRIPTION = 4;
+  // An unrecoverable server-side error ended the stream.
+  STREAM_CLOSED_INTERNAL_ERROR = 5;
+}
+
+// Sent by the server as the FINAL message of a subscription stream to inform the
+// client why the stream is being closed. When the `stream_closed` field is present
+// on a streamed update, the message carries no update data and the stream ends
+// right after it.
+message SubscriptionStreamClosed {
+  SubscriptionStreamClosedReason reason = 1;
+  // Optional human-readable detail, meant for logging/debugging (not for UI).
+  optional string message = 2;
+}
+
 message FriendshipUpdate {
   message RequestResponse {
     FriendProfile friend = 1;
@@ -133,11 +161,19 @@ message FriendshipUpdate {
     CancelResponse cancel = 5;
     BlockResponse block = 6;
   }
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, the `update` oneof is unset.
+  optional SubscriptionStreamClosed stream_closed = 7;
 }
 
 message FriendConnectivityUpdate {
   FriendProfile friend = 1;
   ConnectivityStatus status = 2;
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, all other fields are unset.
+  optional SubscriptionStreamClosed stream_closed = 3;
 }
 
 message GetFriendshipStatusPayload {
@@ -288,12 +324,20 @@ message GetBlockingStatusResponse {
 message BlockUpdate {
   string address = 1;
   bool is_blocked = 2;
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, all other fields are unset.
+  optional SubscriptionStreamClosed stream_closed = 3;
 }
 
 message CommunityMemberConnectivityUpdate {
   string community_id = 1;
   User member = 2;
   ConnectivityStatus status = 3;
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, all other fields are unset.
+  optional SubscriptionStreamClosed stream_closed = 4;
 }
 
 // Private voice chats
@@ -378,6 +422,10 @@ message PrivateVoiceChatUpdate {
   optional User caller = 3;
   optional User callee = 4;
   optional PrivateVoiceChatCredentials credentials = 5;
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, all other fields are unset.
+  optional SubscriptionStreamClosed stream_closed = 6;
 }
 
 // Ending a private voice chat
@@ -618,6 +666,10 @@ message CommunityVoiceChatUpdate {
   string community_name = 7; // Name of the community
   optional string community_image = 8; // Image/picture of the community
   repeated string worlds = 9; // World names associated with the community (world: true)
+
+  // Present only on the final message of the stream; explains why the server closed it.
+  // When set, all other fields are unset.
+  optional SubscriptionStreamClosed stream_closed = 10;
 }
 
 service SocialService {  

--- a/proto/decentraland/social_service/v2/social_service_v2.proto
+++ b/proto/decentraland/social_service/v2/social_service_v2.proto
@@ -114,20 +114,16 @@ message UpsertFriendshipResponse {
 
 // Subscription stream lifecycle
 
-// Reason codes for a server-initiated closure of a subscription stream.
+// Reason codes for a server-initiated closure of a subscription stream. Only reasons that
+// can actually be delivered are listed: a close notice reaches the client as the final
+// stream message, which requires the connection to still be alive. That rules out
+// shutdown/stale-cleanup closes, where the socket is already gone before the server tears
+// the subscription down.
 enum SubscriptionStreamClosedReason {
   // The server did not specify a finer-grained reason.
   STREAM_CLOSED_UNKNOWN = 0;
-  // The server is shutting down or draining its connections.
-  STREAM_CLOSED_SERVER_SHUTTING_DOWN = 1;
   // The connection already has an active subscription for this stream.
-  STREAM_CLOSED_DUPLICATE_SUBSCRIPTION = 2;
-  // The connection is no longer authorized to keep the stream open.
-  STREAM_CLOSED_UNAUTHORIZED = 3;
-  // The server cleaned up the subscription after detecting its state was stale.
-  STREAM_CLOSED_STALE_SUBSCRIPTION = 4;
-  // An unrecoverable server-side error ended the stream.
-  STREAM_CLOSED_INTERNAL_ERROR = 5;
+  STREAM_CLOSED_DUPLICATE_SUBSCRIPTION = 1;
 }
 
 // Sent by the server as the FINAL message of a subscription stream to inform the


### PR DESCRIPTION
## Problem

When the social service closes a subscription stream, the client only sees the stream end — the `@dcl/rpc` close-stream frame has no reason field, so there is no way to tell the client *why*.

## Solution

Application-level close notice in the social service v2 protocol, sent as the **final message** of a stream:

- New `SubscriptionStreamClosed` message: a `SubscriptionStreamClosedReason` plus an optional human-readable `message` for logging/debugging.
- New `optional SubscriptionStreamClosed stream_closed` field on all six streamed update messages (`FriendshipUpdate`, `FriendConnectivityUpdate`, `BlockUpdate`, `CommunityMemberConnectivityUpdate`, `PrivateVoiceChatUpdate`, `CommunityVoiceChatUpdate`).

When `stream_closed` is present the message carries no update data and the stream ends right after it. Uniform across all six streams.

## Reason enum — only what's deliverable

```
enum SubscriptionStreamClosedReason {
  STREAM_CLOSED_UNKNOWN = 0;
  STREAM_CLOSED_DUPLICATE_SUBSCRIPTION = 1;
}
```

A close notice can only reach the client while its connection is still alive (it travels as the final stream element, which the client must still be able to ACK). That holds for the **duplicate-subscription rejection** and essentially nothing else: shutdown and stale-cleanup closes happen *after* the socket is already gone, so those reasons could never be delivered. Rather than ship enum values that are dead on arrival, the enum keeps only `UNKNOWN` (proto3 zero default) and `DUPLICATE_SUBSCRIPTION`. It stays extensible — a future *deliverable* reason can be added.

## Compatibility

- New messages/enum/fields only — wire- and JSON-compatible, verified with `buf breaking` against `main`.
- Old clients see a final message with an unknown field followed by a normal stream end.

## Verification

- `make buf-lint`, `make buf-build`, `make buf-breaking` pass.
- Codegen + TypeScript compile (`scripts/test.sh`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)