### PR TITLE
feat: add double jump and glide fields to AvatarLocomotionSettings

### DIFF
--- a/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
+++ b/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
@@ -15,4 +15,7 @@ message PBAvatarLocomotionSettings {
   optional float jump_height = 4;           // Height of a regular jump (in meters)
   optional float run_jump_height = 5;       // Height of a jump while running (in meters)
   optional float hard_landing_cooldown = 6; // Cooldown time after a hard landing before the avatar can move again (in seconds)
+  optional float double_jump_height = 7;    // Height of the double jump (in meters)
+  optional float gliding_speed = 8;         // Maximum speed when gliding (in meters per second)
+  optional float gliding_falling_speed = 9; // Maximum falling speed when gliding (in meters per second)
 }


### PR DESCRIPTION
Ports the three `PBAvatarLocomotionSettings` tuning fields from `experimental`/`main` into `protocol-squad`:

- `double_jump_height` (field 7)
- `gliding_speed` (field 8)
- `gliding_falling_speed` (field 9)

These were added on `experimental` in #340 and promoted to `main` in #407, but were missing from `protocol-squad` (which only carried fields 1–6 from #398). Field numbers match `experimental`/`main` exactly; existing fields 1–6 are unchanged.

Cherry-pick of #407 (`c96236d`).