### PR TITLE
feat: Pulse scene listeners

### DIFF
--- a/proto/decentraland/pulse/pulse_client.proto
+++ b/proto/decentraland/pulse/pulse_client.proto
@@ -66,6 +66,27 @@ message TeleportRequest {
   string realm = 5;
 }
 
+// Inclusive rectangle in parcel coordinates. A single parcel is min == max.
+message ParcelRect {
+  sint32 min_x = 1;
+  sint32 min_z = 2;
+  sint32 max_x = 3;
+  sint32 max_z = 4;
+}
+
+// Scene-listener connect: same signed-fetch auth chain as HandshakeRequest, plus an
+// immutable parcel-set area of interest. No initial state — a listener is never a subject.
+message SceneListenerHandshakeRequest {
+  // Signed-fetch headers JSON — identical shape to HandshakeRequest.auth_chain.
+  bytes auth_chain = 1;
+  // AoI realm partition — same rules as TeleportRequest.realm.
+  string realm = 2;
+  // Announced AoI as inclusive parcel-coordinate rects; fixed for the connection
+  // lifetime. The sum of rect areas is capped server-side (SceneListener:MaxParcels) —
+  // overlaps count per rect, so announce disjoint rects.
+  repeated ParcelRect parcel_rects = 3;
+}
+
 message ClientMessage {
   oneof message {
     HandshakeRequest handshake = 1;
@@ -75,5 +96,6 @@ message ClientMessage {
     EmoteStart emote_start = 5;
     EmoteStop emote_stop = 6;
     TeleportRequest teleport = 7;
+    SceneListenerHandshakeRequest scene_listener_handshake = 8;
   }
 }


### PR DESCRIPTION
## Summary

Split out of #449 so the base Pulse protocol can land in `main` without the scene-listeners surface. This PR re-targets the scene listeners work (originally #437) onto `feat/pulse`:

- `SceneListenerHandshakeRequest` — scene-listener connect message as `ClientMessage` oneof case `8`: same signed-fetch `auth_chain` shape as `HandshakeRequest`, `realm` partition, and an immutable area of interest fixed for the connection lifetime. A listener is never a subject, so there is no initial state.
- `ParcelRect` — inclusive parcel-coordinate rects (`sint32`) so large scenes announce their AoI in a few bytes; the sum of rect areas is capped server-side (`SceneListener:MaxParcels`).

## Test plan

- [ ] `protoc` compiles `pulse_client.proto` cleanly with the new messages
- [ ] Server rejects handshakes whose summed rect area exceeds `SceneListener:MaxParcels`
- [ ] Wire-compat check: existing `ClientMessage` cases (1–7) are unchanged