### PR TITLE
feat: add OpenExplorerUi restricted action (ExplorerUi, OpenExplorerUiResult)

### DIFF
--- a/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -65,6 +65,42 @@ message EmptyResponse { }
 
 message StopEmoteRequest { }
 
+// Identifies which fullscreen explorer panel OpenExplorerUi targets.
+// EU_SETTINGS holds 0 so an unset `ui` field defaults to the least-intrusive panel.
+enum ExplorerUi {
+  EU_SETTINGS = 0;
+  EU_MAP = 1;
+  EU_BACKPACK = 2;
+  EU_CAMERA_REEL = 3;
+  EU_COMMUNITIES = 4;
+  EU_PLACES = 5;
+  EU_EVENTS = 6;
+}
+
+// Verdict of an OpenExplorerUi request (enum rather than a bool so new outcomes stay expressible).
+enum OpenExplorerUiResult {
+  UNSPECIFIED = 0;
+  OPENED = 1;
+  WAS_ALREADY_OPEN = 2;             // a fullscreen panel is already open
+  REJECTED_NOT_CURRENT_SCENE = 3;   // the standard restricted-actions current-scene gate rejected the call
+  REJECTED_FEATURE_DISABLED = 4;    // the requested section is hidden by feature flags or client doesn't have that feature
+  REJECTED_NO_USER_GESTURE = 5;     // rejected: the call did not originate from a user gesture
+}
+
+message OpenExplorerUiRequest {
+  ExplorerUi ui = 1;
+
+  // Extension point for future per-panel parameters, as a oneof so each panel gets its
+  // own optional param message without touching existing fields. 
+  //   message MapParams { int32 focus_x = 1; int32 focus_y = 2; }
+  //   oneof params { MapParams map = 10; }
+}
+
+message OpenExplorerUiResponse {
+  // Carries only the verdict of the open action. 
+  OpenExplorerUiResult open_result = 1;
+}
+
 service RestrictedActionsService {
   // MovePlayerTo will move the player to a position relative to the current scene.
   // If 'duration' field is used in the request, the success response depends on the
@@ -98,4 +134,7 @@ service RestrictedActionsService {
 
   // StopEmote will stop the current emote
   rpc StopEmote(StopEmoteRequest) returns (SuccessResponse) {}
+
+  // OpenExplorerUi opens a specific fullscreen explorer panel and returns the open verdict.
+  rpc OpenExplorerUi(OpenExplorerUiRequest) returns (OpenExplorerUiResponse) {}
 }


### PR DESCRIPTION
## What

Adds an `OpenExplorerUi` RPC to the existing `RestrictedActionsService` so SDK7 scenes can open native explorer UI panels (Map, Settings, Backpack, Camera Reel, Communities, Places, Events) through `~system/RestrictedActions`.

- New enum `ExplorerUi` — 7 fullscreen sections; `EU_SETTINGS` holds the zero value so an unset `ui` field defaults to the least-intrusive panel.
- New enum `OpenExplorerUiResult` — the open verdict: `UNSPECIFIED`, `OPENED`, `WAS_ALREADY_OPEN`, `REJECTED_NOT_CURRENT_SCENE`, `REJECTED_FEATURE_DISABLED`, `REJECTED_NO_USER_GESTURE`.
- New messages `OpenExplorerUiRequest { ExplorerUi ui }` / `OpenExplorerUiResponse { OpenExplorerUiResult open_result }` (dedicated response, not the shared `SuccessResponse`; the request documents a `oneof` extension point for future per-panel params).
- `rpc OpenExplorerUi(OpenExplorerUiRequest) returns (OpenExplorerUiResponse)` on `RestrictedActionsService`.

Additive and non-breaking. Only `proto/decentraland/kernel/apis/restricted_actions.proto` changed.

## Context

Iteration 1 of the Scene-triggered Explorer UI feature. This is the **review PR into `main`** per the protocol contribution flow; #446 carries the exact same change on `experimental` for Unity testing and will be closed once the main→experimental sync lands.

## Testing

Consumed downstream by js-sdk-toolchain (decentraland/js-sdk-toolchain#1485, `~system/RestrictedActions` codegen) and unity-explorer (decentraland/unity-explorer#9472, C# implementation with QA test scene) on matching `feat/scene-triggered-explorer-ui` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)