### PR TITLE
fix: restore ServiceStatus and ServiceDiscoveryMessage to archipelago.proto

### DIFF
--- a/proto/decentraland/kernel/comms/v3/archipelago.proto
+++ b/proto/decentraland/kernel/comms/v3/archipelago.proto
@@ -86,7 +86,7 @@ message IslandStatusMessage {
 }
 
 message ServiceStatus {
-  uint32 current_time = 1;
+  uint64 current_time = 1;
   optional string commit_hash = 2;
   uint32 user_count = 3;
 }

--- a/proto/decentraland/kernel/comms/v3/archipelago.proto
+++ b/proto/decentraland/kernel/comms/v3/archipelago.proto
@@ -84,3 +84,14 @@ message IslandData {
 message IslandStatusMessage {
   repeated IslandData data = 1;
 }
+
+message ServiceStatus {
+  uint32 current_time = 1;
+  optional string commit_hash = 2;
+  uint32 user_count = 3;
+}
+
+message ServiceDiscoveryMessage {
+  string server_name = 1;
+  ServiceStatus status = 2;
+}


### PR DESCRIPTION
Restores `ServiceStatus` and `ServiceDiscoveryMessage` to `kernel/comms/v3/archipelago.proto`. These types are **already in production use** — they just never made it onto `main`.

This is a cherry-pick of the two original commits, authorship preserved, not a rewrite.

## Where it was dropped

Both messages were authored in September 2023 on `feat/default-realm`:

| Commit | Date | What |
|---|---|---|
| `10343e9` | 2023-09-20 | `feat: add new archipelago message` — added both messages, `current_time` as `uint32` |
| `861829b` | 2023-09-22 | `fix: timestamp` — widened `current_time` to `uint64` |

That branch was never merged. Verified against current `main`:

```
git merge-base --is-ancestor 10343e9 origin/main   →  false
git branch -r --contains 10343e9                   →  origin/feat/default-realm   (only)
```

A sweep of every remote branch finds `ServiceDiscoveryMessage` on exactly one: `feat/default-realm`. So for ~3 years `main` has been missing types that production depends on.

## Why it still works

`archipelago-workers` doesn't install a released `@dcl/protocol`. All three services pin a **CDN branch build** — note the `/branch/` path segment:

```
https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-6276153891.commit-3946d15.tgz
```

That tarball was built from the unmerged branch and *does* contain both messages, so `archipelago-core` and `archipelago-stats` have compiled and run fine the whole time. The gap is invisible to anyone consuming the published artifact and only shows up when generating from the repository.

Its source commit `3946d15` is no longer present in this repo at all — the branch it was built from appears to have been deleted after publishing. Production therefore depends on types that exist only in an orphaned build artifact, with no reachable source. That is worth closing on its own merits, independently of the change below.

## Why now

Pulse is taking over island/cluster authorship from `archipelago-core` and must publish the same NATS feeds so `archipelago-stats` keeps working after core is decommissioned:

- `engine.islands` → `IslandStatusMessage` — already on `main` ✅
- `engine.discovery` → `ServiceDiscoveryMessage` — **missing** ❌

Pulse generates C# directly from this repository rather than from an npm tarball, so `protoc` has nothing to emit for `engine.discovery` and the build fails on the missing type.

Consumer for reference — `archipelago-stats` decodes `engine.discovery` into its `coreStatus` component, which serves `GET /core-status`:

```ts
isHealthy:    () => clock.now() - lastMessage.status.currentTime < 90000
getUserCount: () => lastMessage?.status?.userCount ?? 0
```

## Verification

The resulting `archipelago.proto` is byte-identical (line endings aside) to the one inside the production tarball, so nothing on the wire changes:

```
diff --strip-trailing-cr <this branch> <node_modules/@dcl/protocol>  →  identical
```

Note on `current_time`: it must be `uint64`. Epoch milliseconds (~1.75e12) overflow `uint32`, and the health check above is a delta against `Date.now()` — a truncated timestamp would make the service read as permanently unhealthy. `861829b` is included precisely for this reason; cherry-picking only `10343e9` would land the broken width.

Additive change, new messages only. No existing message, field, or tag number is touched.
